### PR TITLE
Add CI workflow, Dependabot, and SDK pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  # NuGet packages — Central Package Management means Directory.Packages.props at
+  # the repo root is the single source of truth. One PR per bump, grouped by minor/patch
+  # so the Tuesday update is one PR not seven.
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+    commit-message:
+      prefix: deps
+    labels: [dependencies, nuget]
+
+  # GitHub Actions used in workflows. Keeps action SHAs/versions current —
+  # matters for supply-chain hygiene and deprecation warnings.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+    commit-message:
+      prefix: ci
+    labels: [dependencies, ci]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR/branch — saves minutes when pushing fixups.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      # Belt-and-braces: the snapshot suite already refuses UPDATE_SNAPSHOTS when
+      # CI is detected, but pin it off explicitly so a stray env var on the agent
+      # can't auto-accept baselines.
+      UPDATE_SNAPSHOTS: '0'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          # Reads global.json for the resolved version; cache keys off the CPM lock.
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: Directory.Packages.props
+
+      - name: Restore
+        run: dotnet restore DiagramForge.slnx
+
+      - name: Build
+        run: dotnet build DiagramForge.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: >
+          dotnet test DiagramForge.slnx
+          --no-build
+          --configuration Release
+          --logger "trx;LogFilePrefix=results"
+          --results-directory TestResults
+
+      # Upload the snapshot .actual.svg gallery even (especially) when tests fail —
+      # that's when you most want to eyeball the rendered output.
+      - name: Upload rendered snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshots
+          path: artifacts/test-results/snapshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/
+          if-no-files-found: warn
+          retention-days: 7

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
## Summary

Bootstraps CI/CD for the repo: build + test on every push/PR, weekly dependency updates, and an SDK version pin.

## Files

### `.github/workflows/ci.yml`

| | |
|---|---|
| Trigger | `push`/`pull_request` to `main`, plus `workflow_dispatch` |
| Runner | `ubuntu-latest` |
| Steps | restore → build (Release) → test — separate so failures point at the right phase |
| Concurrency | Cancels superseded runs on the same ref — no wasted minutes on fixup pushes |
| Artifacts | TRX test results + `artifacts/test-results/snapshots/*.svg` (`if: always()` — you most want rendered output when tests *fail*) |
| NuGet cache | Keyed on `Directory.Packages.props` since the repo uses CPM |
| `UPDATE_SNAPSHOTS` | Explicitly pinned to `0` — the E2E suite already refuses it under `CI`, but defense in depth |

The snapshot artifact upload no-ops (`if-no-files-found: ignore`) until #2 merges, then lights up automatically.

### `.github/dependabot.yml`

- **`nuget`** weekly against `/` — picks up `Directory.Packages.props` for CPM. Minor + patch bumps grouped into one PR so the Tuesday update isn't seven separate reviews.
- **`github-actions`** weekly — keeps `actions/checkout`, `setup-dotnet`, `upload-artifact` pins current.

### `global.json`

```json
{ "sdk": { "version": "10.0.100", "rollForward": "latestFeature", "allowPrerelease": true } }
```

- Gives `actions/setup-dotnet` a deterministic install target
- `rollForward: latestFeature` + `allowPrerelease` means local 10.x/11-preview SDKs keep working — this is a *floor*, not a hard pin

## Ordering with #2

Independent — merge in either order. Merging this first means #2's snapshot suite runs under CI on its own PR.