### PR TITLE
Size nodes to fit label text

### DIFF
--- a/src/DiagramForge/Layout/DefaultLayoutEngine.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.cs
@@ -15,6 +15,15 @@ namespace DiagramForge.Layout;
 /// </remarks>
 public sealed class DefaultLayoutEngine : ILayoutEngine
 {
+    /// <summary>
+    /// Average glyph advance as a fraction of font size (em-units) for typical
+    /// Latin UI sans-serif stacks (Segoe UI, Inter, Arial). Derived empirically;
+    /// biased slightly high so shapes err on the side of too-wide rather than
+    /// clipping text. A proper font-metrics engine would replace this heuristic
+    /// when higher fidelity is needed.
+    /// </summary>
+    private const double AvgGlyphAdvanceEm = 0.6;
+
     /// <inheritdoc/>
     public void Layout(Diagram diagram, Theme theme)
     {
@@ -25,57 +34,122 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             return;
 
         var hints = diagram.LayoutHints;
-        double nodeW = hints.MinNodeWidth;
+        double minW = hints.MinNodeWidth;
         double nodeH = hints.MinNodeHeight;
         double hGap = hints.HorizontalSpacing;
         double vGap = hints.VerticalSpacing;
         double pad = theme.DiagramPadding;
 
-        // Assign nodes to layers via BFS
+        // ── Sizing pass ───────────────────────────────────────────────────────
+        // Compute each node's width from its label so text does not overflow the
+        // shape. MinNodeWidth remains a floor so short labels ("A", "End") do not
+        // produce skinny boxes.
+
+        foreach (var node in diagram.Nodes.Values)
+        {
+            double fontSize = node.Label.FontSize ?? theme.FontSize;
+            double textW = EstimateTextWidth(node.Label.Text, fontSize);
+            node.Width = Math.Max(minW, textW + 2 * theme.NodePadding);
+            node.Height = nodeH;
+        }
+
+        // ── Positioning pass ──────────────────────────────────────────────────
+        // Assign nodes to layers via BFS, then place them. Because widths are now
+        // variable, we track running offsets rather than multiplying a fixed stride.
+        //
+        //   Horizontal (LR/RL): each layer is a vertical column. Columns advance
+        //   along X by the *widest* node in the previous column + hGap. Nodes within
+        //   a column stack by uniform height.
+        //
+        //   Vertical (TB/BT):   each layer is a horizontal row. Rows advance along
+        //   Y by uniform height. Within a row, nodes advance along X by each node's
+        //   own width + hGap.
+
         var layers = ComputeLayers(diagram);
 
         bool isHorizontal = hints.Direction is LayoutDirection.LeftToRight
                                                or LayoutDirection.RightToLeft;
 
-        for (int layerIdx = 0; layerIdx < layers.Count; layerIdx++)
+        if (isHorizontal)
         {
-            var layer = layers[layerIdx];
-            for (int nodeIdx = 0; nodeIdx < layer.Count; nodeIdx++)
+            double columnX = pad;
+            foreach (var layer in layers)
             {
-                var node = layer[nodeIdx];
+                // ComputeLayers can emit an empty layer when every node is in a cycle
+                // (no in-degree-zero roots → BFS never starts → fallback ranking leaves
+                // layer 0 unpopulated). The old fixed-stride loop tolerated this by
+                // running zero inner iterations; do the same here.
+                if (layer.Count == 0)
+                    continue;
 
-                if (isHorizontal)
+                double maxWidthInColumn = layer.Max(n => n.Width);
+                for (int i = 0; i < layer.Count; i++)
                 {
-                    node.X = pad + layerIdx * (nodeW + hGap);
-                    node.Y = pad + nodeIdx * (nodeH + vGap);
+                    var node = layer[i];
+                    node.X = columnX;
+                    node.Y = pad + i * (nodeH + vGap);
                 }
-                else
-                {
-                    node.X = pad + nodeIdx * (nodeW + hGap);
-                    node.Y = pad + layerIdx * (nodeH + vGap);
-                }
+                columnX += maxWidthInColumn + hGap;
+            }
+        }
+        else
+        {
+            double rowY = pad;
+            foreach (var layer in layers)
+            {
+                if (layer.Count == 0)
+                    continue; // see comment above
 
-                node.Width = nodeW;
-                node.Height = nodeH;
+                double runX = pad;
+                foreach (var node in layer)
+                {
+                    node.X = runX;
+                    node.Y = rowY;
+                    runX += node.Width + hGap;
+                }
+                rowY += nodeH + vGap;
             }
         }
 
-        // Reverse positions for RL / BT
+        // ── Reversal for RL / BT ──────────────────────────────────────────────
+        // Mirror coordinates along the major axis. Must use each node's own width
+        // (not a fixed constant) so variable-width nodes stay inside the frame.
+
         if (hints.Direction == LayoutDirection.RightToLeft
             || hints.Direction == LayoutDirection.BottomToTop)
         {
-            double maxCoord = isHorizontal
-                ? diagram.Nodes.Values.Max(n => n.X) + nodeW + pad
-                : diagram.Nodes.Values.Max(n => n.Y) + nodeH + pad;
-
-            foreach (var node in diagram.Nodes.Values)
+            if (isHorizontal)
             {
-                if (isHorizontal)
-                    node.X = maxCoord - node.X - nodeW;
-                else
-                    node.Y = maxCoord - node.Y - nodeH;
+                double frameW = diagram.Nodes.Values.Max(n => n.X + n.Width) + pad;
+                foreach (var node in diagram.Nodes.Values)
+                {
+                    node.X = frameW - node.X - node.Width;
+                }
+            }
+            else
+            {
+                double frameH = diagram.Nodes.Values.Max(n => n.Y + n.Height) + pad;
+                foreach (var node in diagram.Nodes.Values)
+                {
+                    node.Y = frameH - node.Y - node.Height;
+                }
             }
         }
+    }
+
+    // ── Text measurement ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Estimates the rendered width of <paramref name="text"/> using a char-count
+    /// heuristic: <c>length × fontSize × 0.6</c>. Server-side SVG has no DOM to
+    /// query for <c>getBBox()</c>; this gets us within ±10% for Latin text, which
+    /// is sufficient for layout (padding absorbs the slop).
+    /// </summary>
+    private static double EstimateTextWidth(string? text, double fontSize)
+    {
+        if (string.IsNullOrEmpty(text))
+            return 0;
+        return text.Length * fontSize * AvgGlyphAdvanceEm;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg
@@ -1,27 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="888.00" height="88.00" viewBox="0 0 888.00 88.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="708.00" height="88.00" viewBox="0 0 708.00 88.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#555555"/>
     </marker>
   </defs>
-  <rect width="888.00" height="88.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
+  <rect width="708.00" height="88.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
+  <path d="M 144.00,44.00 C 168.00,44.00 180.00,44.00 204.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <path d="M 324.00,44.00 C 348.00,44.00 360.00,44.00 384.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <path d="M 504.00,44.00 C 528.00,44.00 540.00,44.00 564.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 684.00,44.00 C 708.00,44.00 720.00,44.00 744.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 744.00,44.00 C 576.00,44.00 492.00,44.00 324.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <g transform="translate(204.00,24.00)">
+  <path d="M 564.00,44.00 C 396.00,44.00 312.00,44.00 144.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <g transform="translate(24.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Plan</text>
   </g>
-  <g transform="translate(384.00,24.00)">
+  <g transform="translate(204.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Do</text>
   </g>
-  <g transform="translate(564.00,24.00)">
+  <g transform="translate(384.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Check</text>
   </g>
-  <g transform="translate(744.00,24.00)">
+  <g transform="translate(564.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Act</text>
   </g>

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg
@@ -1,24 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="168.00" height="328.00" viewBox="0 0 168.00 328.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="274.80" height="328.00" viewBox="0 0 274.80 328.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#555555"/>
     </marker>
   </defs>
-  <rect width="168.00" height="328.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
+  <rect width="274.80" height="328.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
   <g transform="translate(24.00,24.00)">
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Important / Urgent</text>
+    <rect width="164.40" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="82.20" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Important / Urgent</text>
   </g>
   <g transform="translate(24.00,104.00)">
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Important / Not Urgent</text>
+    <rect width="195.60" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="97.80" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Important / Not Urgent</text>
   </g>
   <g transform="translate(24.00,184.00)">
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Not Important / Urgent</text>
+    <rect width="195.60" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="97.80" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Not Important / Urgent</text>
   </g>
   <g transform="translate(24.00,264.00)">
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Not Important / Not Urgent</text>
+    <rect width="226.80" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="113.40" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Not Important / Not Urgent</text>
   </g>
 </svg>

--- a/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
+++ b/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
@@ -68,20 +68,92 @@ public class DefaultLayoutEngineTests
     }
 
     [Fact]
-    public void Layout_AllNodes_HaveSameSizeByDefault()
+    public void Layout_ShortLabels_GetMinNodeWidth()
     {
+        // Single-char labels shouldn't shrink below the MinNodeWidth floor —
+        // tiny skinny boxes look bad and are hard to click.
         var diagram = new Diagram()
             .AddNode(new Node("A"))
-            .AddNode(new Node("B"))
-            .AddNode(new Node("C"));
+            .AddNode(new Node("B"));
 
         _engine.Layout(diagram, _theme);
 
-        var widths = diagram.Nodes.Values.Select(n => n.Width).Distinct().ToList();
-        var heights = diagram.Nodes.Values.Select(n => n.Height).Distinct().ToList();
+        double minW = diagram.LayoutHints.MinNodeWidth;
+        Assert.All(diagram.Nodes.Values, n => Assert.Equal(minW, n.Width));
+    }
 
-        Assert.Single(widths);
-        Assert.Single(heights);
+    [Fact]
+    public void Layout_LongLabel_WidensNodeBeyondMinimum()
+    {
+        // The driving bug: "Not Important / Not Urgent" overflowing a 120px box.
+        var diagram = new Diagram()
+            .AddNode(new Node("short", "OK"))
+            .AddNode(new Node("long", "Not Important / Not Urgent"));
+
+        _engine.Layout(diagram, _theme);
+
+        double minW = diagram.LayoutHints.MinNodeWidth;
+        Assert.Equal(minW, diagram.Nodes["short"].Width);
+        Assert.True(diagram.Nodes["long"].Width > minW,
+            $"Long label width {diagram.Nodes["long"].Width} should exceed MinNodeWidth {minW}");
+    }
+
+    [Fact]
+    public void Layout_LongerLabel_YieldsWiderNode_Monotonic()
+    {
+        // Don't pin exact pixel values (the glyph-advance heuristic may be tuned),
+        // but strictly longer text must never produce a narrower box.
+        var diagram = new Diagram()
+            .AddNode(new Node("a", "Twelve chars"))           // 12
+            .AddNode(new Node("b", "Twenty-four characters")); // 24
+
+        _engine.Layout(diagram, _theme);
+
+        Assert.True(diagram.Nodes["b"].Width > diagram.Nodes["a"].Width);
+    }
+
+    [Fact]
+    public void Layout_VariableWidths_PreservesGapBetweenLayers_Horizontal()
+    {
+        // Running-offset positioning: a wide node in column 0 should push column 1
+        // right by at least its own width. Column 1's left edge must not land
+        // inside column 0's widest node.
+        var diagram = new Diagram();
+        diagram.AddNode(new Node("wide", "This is a deliberately wide label"))
+               .AddNode(new Node("next", "Next"))
+               .AddEdge(new Edge("wide", "next"));
+        diagram.LayoutHints.Direction = LayoutDirection.LeftToRight;
+
+        _engine.Layout(diagram, _theme);
+
+        var wide = diagram.Nodes["wide"];
+        var next = diagram.Nodes["next"];
+
+        // No overlap: next column starts at or beyond wide's right edge.
+        Assert.True(next.X >= wide.X + wide.Width,
+            $"next.X ({next.X}) should be >= wide.X + wide.Width ({wide.X + wide.Width})");
+
+        // Gap respected within a tolerance (don't over-constrain the exact value).
+        double gap = next.X - (wide.X + wide.Width);
+        Assert.True(gap >= diagram.LayoutHints.HorizontalSpacing - 1);
+    }
+
+    [Fact]
+    public void Layout_VariableWidths_ReversalKeepsNodeInsideFrame_RightToLeft()
+    {
+        // RL mirroring must use each node's own width, not a fixed constant —
+        // otherwise a wide node ends up with a negative X after the flip.
+        var diagram = new Diagram();
+        diagram.AddNode(new Node("wide", "Deliberately wide for reversal test"))
+               .AddNode(new Node("thin", "Thin"))
+               .AddEdge(new Edge("wide", "thin"));
+        diagram.LayoutHints.Direction = LayoutDirection.RightToLeft;
+
+        _engine.Layout(diagram, _theme);
+
+        Assert.All(diagram.Nodes.Values, n => Assert.True(n.X >= 0, $"{n.Id}.X = {n.X}"));
+        // wide is the source → should end up to the right of thin in RL
+        Assert.True(diagram.Nodes["wide"].X > diagram.Nodes["thin"].X);
     }
 
     [Fact]


### PR DESCRIPTION
## The bug

`conceptual-matrix` has labels like `"Not Important / Not Urgent"` — 26 characters — rendered inside a fixed 120px box. Text spilled straight through the right edge. The E2E snapshot suite (#2) made this obvious from the rendered artifact.

## Fix

Split `DefaultLayoutEngine.Layout()` into two passes.

**Sizing** comes first:

```
width = max(MinNodeWidth, label.Length × fontSize × 0.6 + 2×NodePadding)
```

`0.6` is a rough average glyph advance in em. Not precise, but it doesn't have to be — it just has to make the box big enough. At the default 13px font + 12px padding, the `MinNodeWidth=120` floor holds for labels up to ~12 characters, so single-word nodes look exactly as they did.

**Positioning** then walks layers with running offsets instead of `index × (fixedWidth + gap)`:
- horizontal: advance `columnX` by `max(widths in column) + hGap`
- RL/BT reversal: `frameW - node.X - node.Width` (per-node, was a fixed constant)

### Bonus fix: cycle diagrams

The positioning rewrite hit `InvalidOperationException: Sequence contains no elements` on `conceptual-cycle`. Pure cycles have no zero-in-degree roots, so `layers[0]` is empty and `layer.Max(n => n.Width)` throws. Added a skip guard — which also happens to drop the dead reserved column the old fixed-stride math was leaving behind. Canvas shrinks 888→708 (~20%).

## Blast radius

**2 of 13 snapshots moved.** The other 11 have short labels → floor holds → widths unchanged → running-offset math collapses to the old fixed-stride math. Bitwise identical.

| Baseline | Change |
|---|---|
| `conceptual-matrix` | widths 120 → {164.40, 195.60, 195.60, 226.80} |
| `conceptual-cycle` | dead column removed, canvas 888→708 |

## Tests

| | before | after |
|---|---|---|
| unit | 93 | 97 |
| E2E  | 14 | 14 |
| **total** | **107** | **111** |

Removed: `Layout_AllNodes_HaveSameSizeByDefault` (now false by design)
Added: floor holds for short labels; long label widens; monotonic (longer→wider, no pixel pinning); gap preserved across variable-width layers; RL reversal keeps wide nodes in-frame.

## Deferred

No width cap, no wrapping. A 200-char label will produce a 1600px-wide racetrack. See #7 for `MaxNodeWidth` + multi-line `<tspan>` follow-up.