### PR TITLE
Add vertical lifelines to sequence diagram actors

### DIFF
--- a/src/DiagramForge/Rendering/SvgRenderer.cs
+++ b/src/DiagramForge/Rendering/SvgRenderer.cs
@@ -43,6 +43,10 @@ public sealed class SvgRenderer : ISvgRenderer
         foreach (var group in diagram.Groups)
             AppendGroup(sb, group, theme);
 
+        // Sequence-diagram lifelines: dashed vertical lines below each participant box.
+        if (diagram.Metadata.ContainsKey("sequence:canvasHeight"))
+            AppendLifelines(sb, diagram, theme, height);
+
         // Edges (render behind nodes)
         foreach (var edge in diagram.Edges)
         {
@@ -239,6 +243,19 @@ public sealed class SvgRenderer : ISvgRenderer
         if (!string.IsNullOrWhiteSpace(group.Label.Text))
         {
             sb.AppendLine($"""  <text x="{F(group.X + 8)}" y="{F(group.Y + theme.FontSize + 4)}" font-family="{Escape(theme.FontFamily)}" font-size="{F(theme.FontSize * 0.9)}" fill="{Escape(theme.SubtleTextColor)}" font-weight="bold">{Escape(group.Label.Text)}</text>""");
+        }
+    }
+
+    private static void AppendLifelines(StringBuilder sb, Diagram diagram, Theme theme, double canvasHeight)
+    {
+        string stroke = Escape(theme.EdgeColor);
+        double bottomY = canvasHeight - theme.DiagramPadding;
+
+        foreach (var node in diagram.Nodes.Values)
+        {
+            double cx = node.X + node.Width / 2;
+            double topY = node.Y + node.Height;
+            sb.AppendLine($"""  <line x1="{F(cx)}" y1="{F(topY)}" x2="{F(cx)}" y2="{F(bottomY)}" stroke="{stroke}" stroke-width="{F(theme.StrokeWidth)}" stroke-dasharray="6,3"/>""");
         }
     }
 

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg
@@ -5,6 +5,8 @@
     </marker>
   </defs>
   <rect width="348.00" height="228.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
+  <line x1="84.00" y1="64.00" x2="84.00" y2="204.00" stroke="#555555" stroke-width="1.50" stroke-dasharray="6,3"/>
+  <line x1="264.00" y1="64.00" x2="264.00" y2="204.00" stroke="#555555" stroke-width="1.50" stroke-dasharray="6,3"/>
   <path d="M 84.00,84.00 C 156.00,84.00 192.00,84.00 264.00,84.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <text x="174.00" y="80.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280" font-style="italic">Hello</text>
   <path d="M 264.00,124.00 C 192.00,124.00 156.00,124.00 84.00,124.00" fill="none" stroke="#555555" stroke-width="1.50" stroke-dasharray="6,3"  marker-end="url(#arrowhead)" />


### PR DESCRIPTION
## Summary

Sequence diagrams were missing the dashed vertical lifelines below each participant box — a standard visual element in sequence diagrams.

## Changes

- **`SvgRenderer.cs`** — Added `AppendLifelines()` method that draws a dashed vertical `<line>` from the bottom of each actor box down to the canvas bottom (minus padding). Called from `Render()` when the diagram has `sequence:canvasHeight` metadata (i.e., is a sequence diagram). Lifelines render behind message arrows but in front of the background.
- **`mermaid-sequence.expected.svg`** — Updated snapshot baseline to include the two new lifeline elements.

## Testing

All 22 E2E snapshot tests pass, including the updated `mermaid-sequence` fixture.