### PR TITLE
Fix arrowhead orientation on curved diagonal edges

### DIFF
--- a/src/DiagramForge/Rendering/SvgRenderer.cs
+++ b/src/DiagramForge/Rendering/SvgRenderer.cs
@@ -149,7 +149,7 @@ public sealed class SvgRenderer : ISvgRenderer
         double dx = targetCenterX - sourceCenterX;
         double dy = targetCenterY - sourceCenterY;
 
-        double x1, y1, x2, y2, cpOffset;
+        double x1, y1, x2, y2;
         string cp1, cp2;
 
         if (Math.Abs(dx) >= Math.Abs(dy))
@@ -169,10 +169,6 @@ public sealed class SvgRenderer : ISvgRenderer
                 x2 = target.X + target.Width;
                 y2 = targetCenterY;
             }
-
-            cpOffset = Math.Abs(x2 - x1) * 0.4;
-            cp1 = $"{F(x1 + (dx >= 0 ? cpOffset : -cpOffset))},{F(y1)}";
-            cp2 = $"{F(x2 - (dx >= 0 ? cpOffset : -cpOffset))},{F(y2)}";
         }
         else
         {
@@ -191,10 +187,39 @@ public sealed class SvgRenderer : ISvgRenderer
                 x2 = targetCenterX;
                 y2 = target.Y + target.Height;
             }
+        }
 
-            cpOffset = Math.Abs(y2 - y1) * 0.4;
-            cp1 = $"{F(x1)},{F(y1 + (dy >= 0 ? cpOffset : -cpOffset))}";
-            cp2 = $"{F(x2)},{F(y2 - (dy >= 0 ? cpOffset : -cpOffset))}";
+        // Build control points:
+        //  cp1 — axis-aligned from the source anchor so the path departs with a
+        //         smooth curve perpendicular to the node edge.
+        //  cp2 — along the actual source→target direction so that the curve's
+        //         tangent at the endpoint (and therefore the orient="auto"
+        //         arrowhead) matches the visual angle of approach.
+        // For axis-aligned edges both strategies coincide, so curves and arrows
+        // look the same as before.
+        double edgeDx = x2 - x1;
+        double edgeDy = y2 - y1;
+        double edgeLen = Math.Sqrt(edgeDx * edgeDx + edgeDy * edgeDy);
+        double cpDist = edgeLen * 0.4;
+        if (edgeLen > 0)
+        {
+            double ux = edgeDx / edgeLen;
+            double uy = edgeDy / edgeLen;
+
+            // cp1: axis-aligned departure (horizontal or vertical depending on
+            // which node edge the anchor sits on).
+            if (Math.Abs(dx) >= Math.Abs(dy))
+                cp1 = $"{F(x1 + (dx >= 0 ? cpDist : -cpDist))},{F(y1)}";
+            else
+                cp1 = $"{F(x1)},{F(y1 + (dy >= 0 ? cpDist : -cpDist))}";
+
+            // cp2: follows the real edge vector so the arrowhead angles correctly.
+            cp2 = $"{F(x2 - ux * cpDist)},{F(y2 - uy * cpDist)}";
+        }
+        else
+        {
+            cp1 = $"{F(x1)},{F(y1)}";
+            cp2 = $"{F(x2)},{F(y2)}";
         }
 
         // Per-message Y override: sequence diagrams store an explicit Y position for each
@@ -207,9 +232,9 @@ public sealed class SvgRenderer : ISvgRenderer
             y1 = msgY;
             x2 = targetCenterX;
             y2 = msgY;
-            cpOffset = Math.Abs(x2 - x1) * 0.4;
-            cp1 = $"{F(x1 + (x2 >= x1 ? cpOffset : -cpOffset))},{F(y1)}";
-            cp2 = $"{F(x2 - (x2 >= x1 ? cpOffset : -cpOffset))},{F(y2)}";
+            double seqOffset = Math.Abs(x2 - x1) * 0.4;
+            cp1 = $"{F(x1 + (x2 >= x1 ? seqOffset : -seqOffset))},{F(y1)}";
+            cp2 = $"{F(x2 - (x2 >= x1 ? seqOffset : -seqOffset))},{F(y2)}";
         }
 
         string strokeColor = Escape(edge.Color ?? theme.EdgeColor);

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-hierarchy.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-hierarchy.expected.svg
@@ -6,7 +6,7 @@
   </defs>
   <rect width="348.00" height="168.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
   <path d="M 84.00,64.00 C 84.00,80.00 84.00,88.00 84.00,104.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 144.00,44.00 C 168.00,44.00 180.00,124.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 144.00,44.00 C 184.00,44.00 180.00,92.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <g transform="translate(24.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">CEO</text>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg
@@ -6,7 +6,7 @@
   </defs>
   <rect width="424.00" height="200.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
   <path d="M 144.00,48.00 C 198.40,48.00 225.60,48.00 280.00,48.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 400.00,156.00 C 448.00,156.00 232.00,48.00 280.00,48.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 400.00,156.00 C 464.58,156.00 328.00,91.20 280.00,48.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <text x="340.00" y="98.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280" font-style="italic">events</text>
   <g transform="translate(24.00,28.00)">
     <rect width="120.00" height="40.00" rx="0" ry="0" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg
@@ -7,7 +7,7 @@
   <rect width="348.00" height="168.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
   <path d="M 144.00,44.00 C 168.00,44.00 180.00,44.00 204.00,44.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <text x="174.00" y="40.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280" font-style="italic">yes</text>
-  <path d="M 144.00,44.00 C 168.00,44.00 180.00,124.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 144.00,44.00 C 184.00,44.00 180.00,92.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <text x="174.00" y="80.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280" font-style="italic">no</text>
   <g transform="translate(24.00,24.00)">
     <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg
@@ -7,9 +7,9 @@
   <rect width="528.00" height="248.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
   <path d="M 84.00,64.00 C 84.00,80.00 84.00,88.00 84.00,104.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <path d="M 84.00,144.00 C 84.00,160.00 84.00,168.00 84.00,184.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 144.00,124.00 C 168.00,124.00 180.00,204.00 204.00,204.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 144.00,44.00 C 168.00,44.00 180.00,124.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
-  <path d="M 144.00,44.00 C 240.00,44.00 288.00,124.00 384.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 144.00,124.00 C 184.00,124.00 180.00,172.00 204.00,204.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 144.00,44.00 C 184.00,44.00 180.00,92.00 204.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <path d="M 144.00,44.00 C 245.19,44.00 288.00,92.00 384.00,124.00" fill="none" stroke="#555555" stroke-width="1.50"  marker-end="url(#arrowhead)" />
   <g transform="translate(24.00,24.00)">
     <ellipse cx="60.00" cy="20.00" rx="60.00" ry="20.00" fill="#DAE8FC" stroke="#4F81BD" stroke-width="1.50"/>
     <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937">Product</text>


### PR DESCRIPTION
## Summary

Arrowhead markers on diagonal edges pointed straight horizontally/vertically instead of matching the curve's visual angle. Most visible on the mindmap's Design and Frontend connectors.

## Root cause

Both cubic bezier control points (cp1, cp2) were axis-aligned, so the tangent at the target endpoint was always horizontal or vertical — and `orient="auto"` on the SVG marker follows that tangent.

## Fix

Hybrid control point strategy in `SvgRenderer.AppendEdge`:
- **cp1** (source): axis-aligned for smooth curved departure from the node edge
- **cp2** (target): follows the actual edge direction so the arrowhead angles correctly

For purely horizontal/vertical edges the two approaches coincide, so those are unchanged.

## Changed files

- `SvgRenderer.cs` — updated control point calculation
- 4 snapshot baselines updated: `mermaid-mindmap`, `mermaid-block`, `mermaid-edge-labels`, `conceptual-hierarchy`

## Testing

229 unit tests + 22 E2E snapshot tests all pass.