### PR TITLE
feat: add support for xychart diagrams in Mermaid parser

### DIFF
--- a/src/DiagramForge/Layout/DefaultLayoutEngine.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.cs
@@ -79,6 +79,12 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             return;
         }
 
+        if (string.Equals(diagram.DiagramType, "xychart", StringComparison.OrdinalIgnoreCase))
+        {
+            LayoutXyChartDiagram(diagram, theme, pad);
+            return;
+        }
+
         // ── Sizing pass ───────────────────────────────────────────────────────
         // Compute each node's width from its label so text does not overflow the
         // shape. MinNodeWidth remains a floor so short labels ("A", "End") do not
@@ -625,6 +631,93 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             eventNode.Y = periodY + nodeH + vGap + eIdx * (nodeH + vGap);
             eventNode.Width = colWidth;
         }
+    }
+
+    private static void LayoutXyChartDiagram(
+        Diagram diagram,
+        Theme theme,
+        double pad)
+    {
+        // Chart dimensions.
+        const double ChartWidth = 500;
+        const double ChartHeight = 300;
+        const double AxisLabelMarginLeft = 50;
+        const double AxisLabelMarginBottom = 30;
+
+        double titleOffset = !string.IsNullOrWhiteSpace(diagram.Title) ? theme.TitleFontSize + 8 : 0;
+
+        // Chart area origin (top-left of the plot region).
+        double chartX = pad + AxisLabelMarginLeft;
+        double chartY = pad + titleOffset;
+        double plotWidth = ChartWidth;
+        double plotHeight = ChartHeight;
+
+        // Read axis metadata.
+        int categoryCount = diagram.Metadata.TryGetValue("xychart:categoryCount", out var ccObj)
+            ? Convert.ToInt32(ccObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+        double yMin = diagram.Metadata.TryGetValue("xychart:yMin", out var yMinObj)
+            ? Convert.ToDouble(yMinObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+        double yMax = diagram.Metadata.TryGetValue("xychart:yMax", out var yMaxObj)
+            ? Convert.ToDouble(yMaxObj, System.Globalization.CultureInfo.InvariantCulture) : 100;
+        int barSeriesCount = diagram.Metadata.TryGetValue("xychart:barSeriesCount", out var bscObj)
+            ? Convert.ToInt32(bscObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+
+        double yRange = yMax - yMin;
+        if (yRange <= 0) yRange = 1;
+
+        double categoryWidth = categoryCount > 0 ? plotWidth / categoryCount : plotWidth;
+        double barGroupWidth = categoryWidth * 0.7;
+        double barWidth = barSeriesCount > 0 ? barGroupWidth / barSeriesCount : barGroupWidth;
+        double barOffsetInCategory = (categoryWidth - barGroupWidth) / 2;
+
+        // Store chart geometry for the renderer.
+        diagram.Metadata["xychart:chartX"] = chartX;
+        diagram.Metadata["xychart:chartY"] = chartY;
+        diagram.Metadata["xychart:plotWidth"] = plotWidth;
+        diagram.Metadata["xychart:plotHeight"] = plotHeight;
+
+        foreach (var node in diagram.Nodes.Values)
+        {
+            if (!node.Metadata.TryGetValue("xychart:kind", out var kindObj))
+                continue;
+
+            var kind = kindObj as string;
+            int ci = node.Metadata.TryGetValue("xychart:categoryIndex", out var ciObj)
+                ? Convert.ToInt32(ciObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+            double value = node.Metadata.TryGetValue("xychart:value", out var valObj)
+                ? Convert.ToDouble(valObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+
+            // Clamp value to axis range.
+            double clampedValue = Math.Max(yMin, Math.Min(yMax, value));
+            double normalized = (clampedValue - yMin) / yRange;
+            double barHeight = normalized * plotHeight;
+
+            if (kind == "bar")
+            {
+                int si = node.Metadata.TryGetValue("xychart:seriesIndex", out var siObj)
+                    ? Convert.ToInt32(siObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+
+                node.X = chartX + ci * categoryWidth + barOffsetInCategory + si * barWidth;
+                node.Y = chartY + plotHeight - barHeight;
+                node.Width = barWidth;
+                node.Height = barHeight;
+            }
+            else if (kind == "linePoint")
+            {
+                double pointX = chartX + ci * categoryWidth + categoryWidth / 2;
+                double pointY = chartY + plotHeight - normalized * plotHeight;
+                node.X = pointX - 3;
+                node.Y = pointY - 3;
+                node.Width = 6;
+                node.Height = 6;
+            }
+        }
+
+        // Store the total canvas dimensions so the renderer can size the SVG.
+        double canvasWidth = chartX + plotWidth + pad;
+        double canvasHeight = chartY + plotHeight + AxisLabelMarginBottom + pad;
+        diagram.Metadata["xychart:canvasWidth"] = canvasWidth;
+        diagram.Metadata["xychart:canvasHeight"] = canvasHeight;
     }
 
     // ── Text measurement ──────────────────────────────────────────────────────

--- a/src/DiagramForge/Parsers/Mermaid/MermaidDiagramKind.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidDiagramKind.cs
@@ -10,4 +10,5 @@ internal enum MermaidDiagramKind
     SequenceDiagram,
     Timeline,
     ArchitectureDiagram,
+    XyChart,
 }

--- a/src/DiagramForge/Parsers/Mermaid/MermaidDocument.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidDocument.cs
@@ -66,7 +66,6 @@ internal sealed class MermaidDocument
         "packet-beta",
         "kanban",
         "sankey-beta",
-        "xychart-beta",
         "zenuml",
     };
 
@@ -138,7 +137,11 @@ internal sealed class MermaidDocument
             kind = MermaidDiagramKind.ArchitectureDiagram;
             return true;
         }
-
+        if (normalizedHeader.Equals("xychart-beta", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = MermaidDiagramKind.XyChart;
+            return true;
+        }
         var spaceIndex = normalizedHeader.IndexOf(' ');
         var keyword = spaceIndex >= 0 ? normalizedHeader[..spaceIndex] : normalizedHeader;
         if (KnownUnsupportedMermaidKeywords.Contains(keyword))

--- a/src/DiagramForge/Parsers/Mermaid/MermaidParser.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidParser.cs
@@ -29,9 +29,10 @@ public sealed class MermaidParser : IDiagramParser
         new MermaidSequenceParser(),
         new MermaidTimelineParser(),
         new MermaidArchitectureParser(),
+        new MermaidXyChartParser(),
     ];
 
-    private static readonly string[] SupportedDiagramTypes = ["flowchart", "mindmap", "statediagram", "block", "sequencediagram", "timeline", "architecture"];
+    private static readonly string[] SupportedDiagramTypes = ["flowchart", "mindmap", "statediagram", "block", "sequencediagram", "timeline", "architecture", "xychart-beta"];
 
     public string SyntaxId => "mermaid";
 

--- a/src/DiagramForge/Parsers/Mermaid/MermaidXyChartParser.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidXyChartParser.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DiagramForge.Models;
+
+namespace DiagramForge.Parsers.Mermaid;
+
+/// <summary>
+/// Parses Mermaid <c>xychart-beta</c> diagrams into the semantic model.
+/// </summary>
+/// <remarks>
+/// Supported syntax (v1 subset):
+/// <list type="bullet">
+///   <item><c>xychart-beta</c> header</item>
+///   <item>Optional <c>title "…"</c></item>
+///   <item><c>x-axis</c> with category labels <c>[a, b, c]</c> or numeric range <c>min --&gt; max</c></item>
+///   <item><c>y-axis</c> with optional label and optional <c>min --&gt; max</c> range</item>
+///   <item><c>bar [v1, v2, …]</c> data series (multiple allowed)</item>
+///   <item><c>line [v1, v2, …]</c> data series (multiple allowed)</item>
+/// </list>
+/// </remarks>
+internal sealed class MermaidXyChartParser : IMermaidDiagramParser
+{
+    // Palette for bar and line series — matches the renderer's SeriesPalette.
+    private static readonly string[] SeriesPalette =
+    [
+        "#4F81BD", "#70AD47", "#ED7D31", "#FFC000", "#5B9BD5",
+        "#A5A5A5", "#264478", "#9B57A0", "#636363", "#255E91",
+    ];
+    // Matches a bracketed list of values: [a, b, c] or [100, 200, 300]
+    private static readonly Regex BracketListRegex = new(
+        @"\[([^\]]*)\]",
+        RegexOptions.Compiled);
+
+    // Matches a numeric range: 4000 --> 11000
+    private static readonly Regex NumericRangeRegex = new(
+        @"([\d.]+)\s*-->\s*([\d.]+)",
+        RegexOptions.Compiled);
+
+    // Matches a quoted string: "Sales Revenue"
+    private static readonly Regex QuotedStringRegex = new(
+        @"""([^""]*)""",
+        RegexOptions.Compiled);
+
+    public bool CanParse(MermaidDiagramKind kind) => kind == MermaidDiagramKind.XyChart;
+
+    public Diagram Parse(MermaidDocument document)
+    {
+        var builder = new DiagramSemanticModelBuilder()
+            .WithSourceSyntax("mermaid")
+            .WithDiagramType("xychart");
+
+        string[]? xCategories = null;
+        double? xMin = null, xMax = null;
+        string? yLabel = null;
+        double? yMin = null, yMax = null;
+        var barSeries = new List<double[]>();
+        var lineSeries = new List<double[]>();
+
+        // Skip index 0 (the "xychart-beta" header).
+        for (int i = 1; i < document.Lines.Length; i++)
+        {
+            var line = document.Lines[i];
+
+            // title "…" or title …
+            if (line.StartsWith("title ", StringComparison.OrdinalIgnoreCase))
+            {
+                var titleText = line["title ".Length..].Trim();
+                var quoted = QuotedStringRegex.Match(titleText);
+                builder.WithTitle(quoted.Success ? quoted.Groups[1].Value : titleText);
+                continue;
+            }
+
+            // x-axis [jan, feb, mar] or x-axis "Label" [jan, feb, mar] or x-axis min --> max
+            if (line.StartsWith("x-axis", StringComparison.OrdinalIgnoreCase))
+            {
+                var rest = line["x-axis".Length..].Trim();
+                var bracketMatch = BracketListRegex.Match(rest);
+                if (bracketMatch.Success)
+                {
+                    xCategories = ParseStringList(bracketMatch.Groups[1].Value);
+                }
+                else
+                {
+                    var rangeMatch = NumericRangeRegex.Match(rest);
+                    if (rangeMatch.Success)
+                    {
+                        xMin = ParseDouble(rangeMatch.Groups[1].Value);
+                        xMax = ParseDouble(rangeMatch.Groups[2].Value);
+                    }
+                }
+                continue;
+            }
+
+            // y-axis "Revenue (in $)" 4000 --> 11000
+            if (line.StartsWith("y-axis", StringComparison.OrdinalIgnoreCase))
+            {
+                var rest = line["y-axis".Length..].Trim();
+                var quotedMatch = QuotedStringRegex.Match(rest);
+                if (quotedMatch.Success)
+                {
+                    yLabel = quotedMatch.Groups[1].Value;
+                    rest = rest[(quotedMatch.Index + quotedMatch.Length)..].Trim();
+                }
+                var rangeMatch = NumericRangeRegex.Match(rest);
+                if (rangeMatch.Success)
+                {
+                    yMin = ParseDouble(rangeMatch.Groups[1].Value);
+                    yMax = ParseDouble(rangeMatch.Groups[2].Value);
+                }
+                continue;
+            }
+
+            // bar [5000, 6000, 7500]
+            if (line.StartsWith("bar", StringComparison.OrdinalIgnoreCase))
+            {
+                var bracketMatch = BracketListRegex.Match(line);
+                if (bracketMatch.Success)
+                    barSeries.Add(ParseDoubleList(bracketMatch.Groups[1].Value));
+                continue;
+            }
+
+            // line [5000, 6000, 7000]
+            if (line.StartsWith("line", StringComparison.OrdinalIgnoreCase))
+            {
+                var bracketMatch = BracketListRegex.Match(line);
+                if (bracketMatch.Success)
+                    lineSeries.Add(ParseDoubleList(bracketMatch.Groups[1].Value));
+                continue;
+            }
+        }
+
+        // Determine category count from the data or axis definition.
+        int categoryCount = xCategories?.Length ?? 0;
+        if (categoryCount == 0)
+        {
+            foreach (var s in barSeries)
+                categoryCount = Math.Max(categoryCount, s.Length);
+            foreach (var s in lineSeries)
+                categoryCount = Math.Max(categoryCount, s.Length);
+        }
+
+        // Generate default category labels if only a numeric range was given.
+        xCategories ??= GenerateNumericLabels(categoryCount, xMin, xMax);
+
+        // Auto-compute Y range from data if not specified.
+        var allValues = barSeries.SelectMany(s => s)
+            .Concat(lineSeries.SelectMany(s => s))
+            .ToList();
+
+        if (allValues.Count > 0)
+        {
+            yMin ??= 0;
+            yMax ??= allValues.Max() * 1.1; // 10% headroom
+        }
+        else
+        {
+            yMin ??= 0;
+            yMax ??= 100;
+        }
+
+        // Store chart metadata for layout and rendering.
+        var diagram = builder.Build();
+        diagram.Metadata["xychart:categoryCount"] = categoryCount;
+        diagram.Metadata["xychart:categories"] = xCategories;
+        diagram.Metadata["xychart:yMin"] = yMin.Value;
+        diagram.Metadata["xychart:yMax"] = yMax.Value;
+        if (yLabel is not null)
+            diagram.Metadata["xychart:yLabel"] = yLabel;
+
+        // Create bar nodes — one per data point per series.
+        int seriesIndex = 0;
+        foreach (var series in barSeries)
+        {
+            for (int ci = 0; ci < series.Length && ci < categoryCount; ci++)
+            {
+                var id = $"bar_{seriesIndex}_{ci}";
+                var node = new Node(id, string.Empty) { Shape = Shape.Rectangle };
+                node.FillColor = SeriesPalette[seriesIndex % SeriesPalette.Length];
+                node.StrokeColor = SeriesPalette[seriesIndex % SeriesPalette.Length];
+                node.Metadata["xychart:kind"] = "bar";
+                node.Metadata["xychart:seriesIndex"] = seriesIndex;
+                node.Metadata["xychart:categoryIndex"] = ci;
+                node.Metadata["xychart:value"] = series[ci];
+                diagram.AddNode(node);
+            }
+            seriesIndex++;
+        }
+
+        // Create line-point nodes — one per data point per series.
+        int lineSeriesIndex = 0;
+        foreach (var series in lineSeries)
+        {
+            for (int ci = 0; ci < series.Length && ci < categoryCount; ci++)
+            {
+                var id = $"line_{lineSeriesIndex}_{ci}";
+                var node = new Node(id, string.Empty) { Shape = Shape.Circle };
+                string lineColor = SeriesPalette[(barSeries.Count + lineSeriesIndex) % SeriesPalette.Length];
+                node.FillColor = lineColor;
+                node.StrokeColor = lineColor;
+                node.Metadata["xychart:kind"] = "linePoint";
+                node.Metadata["xychart:seriesIndex"] = lineSeriesIndex;
+                node.Metadata["xychart:categoryIndex"] = ci;
+                node.Metadata["xychart:value"] = series[ci];
+                diagram.AddNode(node);
+            }
+            lineSeriesIndex++;
+        }
+
+        // Store series counts for rendering.
+        diagram.Metadata["xychart:barSeriesCount"] = barSeries.Count;
+        diagram.Metadata["xychart:lineSeriesCount"] = lineSeries.Count;
+
+        return diagram;
+    }
+
+    private static string[] ParseStringList(string csv)
+    {
+        return csv.Split(',')
+            .Select(s => s.Trim().Trim('"'))
+            .Where(s => !string.IsNullOrEmpty(s))
+            .ToArray();
+    }
+
+    private static double[] ParseDoubleList(string csv)
+    {
+        return csv.Split(',')
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrEmpty(s))
+            .Select(ParseDouble)
+            .ToArray();
+    }
+
+    private static double ParseDouble(string s)
+    {
+        return double.Parse(s.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+
+    private static string[] GenerateNumericLabels(int count, double? min, double? max)
+    {
+        if (count == 0) return [];
+        if (min is not null && max is not null && count > 0)
+        {
+            double step = (max.Value - min.Value) / Math.Max(1, count - 1);
+            return Enumerable.Range(0, count)
+                .Select(i => (min.Value + i * step).ToString("G", CultureInfo.InvariantCulture))
+                .ToArray();
+        }
+        return Enumerable.Range(1, count).Select(i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
+    }
+}

--- a/src/DiagramForge/Rendering/SvgRenderer.cs
+++ b/src/DiagramForge/Rendering/SvgRenderer.cs
@@ -47,6 +47,10 @@ public sealed class SvgRenderer : ISvgRenderer
         if (diagram.Metadata.ContainsKey("sequence:canvasHeight"))
             AppendLifelines(sb, diagram, theme, height);
 
+        // XY chart axes, grid lines, and line series.
+        if (diagram.Metadata.ContainsKey("xychart:chartX"))
+            AppendXyChartAxes(sb, diagram, theme);
+
         // Edges (render behind nodes)
         foreach (var edge in diagram.Edges)
         {
@@ -302,6 +306,98 @@ public sealed class SvgRenderer : ISvgRenderer
         }
     }
 
+    // Palette for XY chart series (bars and lines cycle through these).
+    private static readonly string[] SeriesPalette =
+    [
+        "#4F81BD", "#70AD47", "#ED7D31", "#FFC000", "#5B9BD5",
+        "#A5A5A5", "#264478", "#9B57A0", "#636363", "#255E91",
+    ];
+
+    private static void AppendXyChartAxes(StringBuilder sb, Diagram diagram, Theme theme)
+    {
+        double chartX = Convert.ToDouble(diagram.Metadata["xychart:chartX"], System.Globalization.CultureInfo.InvariantCulture);
+        double chartY = Convert.ToDouble(diagram.Metadata["xychart:chartY"], System.Globalization.CultureInfo.InvariantCulture);
+        double plotWidth = Convert.ToDouble(diagram.Metadata["xychart:plotWidth"], System.Globalization.CultureInfo.InvariantCulture);
+        double plotHeight = Convert.ToDouble(diagram.Metadata["xychart:plotHeight"], System.Globalization.CultureInfo.InvariantCulture);
+        double yMin = Convert.ToDouble(diagram.Metadata["xychart:yMin"], System.Globalization.CultureInfo.InvariantCulture);
+        double yMax = Convert.ToDouble(diagram.Metadata["xychart:yMax"], System.Globalization.CultureInfo.InvariantCulture);
+        int categoryCount = Convert.ToInt32(diagram.Metadata["xychart:categoryCount"], System.Globalization.CultureInfo.InvariantCulture);
+        var categories = diagram.Metadata["xychart:categories"] as string[] ?? [];
+        int lineSeriesCount = diagram.Metadata.TryGetValue("xychart:lineSeriesCount", out var lscObj)
+            ? Convert.ToInt32(lscObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+
+        string axisColor = Escape(theme.EdgeColor);
+        string textColor = Escape(theme.SubtleTextColor);
+        double fontSize = theme.FontSize * 0.85;
+        string fontFamily = Escape(theme.FontFamily);
+        double categoryWidth = categoryCount > 0 ? plotWidth / categoryCount : plotWidth;
+
+        // Y-axis line
+        sb.AppendLine($"""  <line x1="{F(chartX)}" y1="{F(chartY)}" x2="{F(chartX)}" y2="{F(chartY + plotHeight)}" stroke="{axisColor}" stroke-width="{F(theme.StrokeWidth)}"/>""");
+
+        // X-axis line
+        sb.AppendLine($"""  <line x1="{F(chartX)}" y1="{F(chartY + plotHeight)}" x2="{F(chartX + plotWidth)}" y2="{F(chartY + plotHeight)}" stroke="{axisColor}" stroke-width="{F(theme.StrokeWidth)}"/>""");
+
+        // Y-axis ticks and labels (5 evenly spaced)
+        int yTickCount = 5;
+        double yRange = yMax - yMin;
+        for (int t = 0; t <= yTickCount; t++)
+        {
+            double frac = (double)t / yTickCount;
+            double yPos = chartY + plotHeight - frac * plotHeight;
+            double yVal = yMin + frac * yRange;
+            string label = yVal.ToString("N0", System.Globalization.CultureInfo.InvariantCulture);
+
+            // Tick mark
+            sb.AppendLine($"""  <line x1="{F(chartX - 4)}" y1="{F(yPos)}" x2="{F(chartX)}" y2="{F(yPos)}" stroke="{axisColor}" stroke-width="{F(theme.StrokeWidth)}"/>""");
+
+            // Grid line (light)
+            if (t > 0 && t < yTickCount)
+                sb.AppendLine($"""  <line x1="{F(chartX)}" y1="{F(yPos)}" x2="{F(chartX + plotWidth)}" y2="{F(yPos)}" stroke="{axisColor}" stroke-width="0.5" opacity="0.2"/>""");
+
+            // Label
+            sb.AppendLine($"""  <text x="{F(chartX - 8)}" y="{F(yPos + fontSize * 0.35)}" text-anchor="end" font-family="{fontFamily}" font-size="{F(fontSize)}" fill="{textColor}">{Escape(label)}</text>""");
+        }
+
+        // X-axis category labels
+        for (int ci = 0; ci < categoryCount && ci < categories.Length; ci++)
+        {
+            double labelX = chartX + ci * categoryWidth + categoryWidth / 2;
+            double labelY = chartY + plotHeight + fontSize + 4;
+            sb.AppendLine($"""  <text x="{F(labelX)}" y="{F(labelY)}" text-anchor="middle" font-family="{fontFamily}" font-size="{F(fontSize)}" fill="{textColor}">{Escape(categories[ci])}</text>""");
+        }
+
+        // Y-axis label (rotated)
+        if (diagram.Metadata.TryGetValue("xychart:yLabel", out var yLabelObj) && yLabelObj is string yLabel)
+        {
+            double labelX = chartX - 40;
+            double labelY = chartY + plotHeight / 2;
+            sb.AppendLine($"""  <text x="{F(labelX)}" y="{F(labelY)}" text-anchor="middle" font-family="{fontFamily}" font-size="{F(fontSize)}" fill="{textColor}" transform="rotate(-90,{F(labelX)},{F(labelY)})">{Escape(yLabel)}</text>""");
+        }
+
+        // Line series polylines
+        for (int si = 0; si < lineSeriesCount; si++)
+        {
+            var points = diagram.Nodes.Values
+                .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "linePoint"
+                         && n.Metadata.TryGetValue("xychart:seriesIndex", out var siObj)
+                         && Convert.ToInt32(siObj, System.Globalization.CultureInfo.InvariantCulture) == si)
+                .OrderBy(n => Convert.ToInt32(n.Metadata["xychart:categoryIndex"], System.Globalization.CultureInfo.InvariantCulture))
+                .Select(n => $"{F(n.X + n.Width / 2)},{F(n.Y + n.Height / 2)}")
+                .ToList();
+
+            if (points.Count < 2)
+                continue;
+
+            // Bar series get lower palette indices; line series start after them.
+            int barSeriesCount = diagram.Metadata.TryGetValue("xychart:barSeriesCount", out var bscObj)
+                ? Convert.ToInt32(bscObj, System.Globalization.CultureInfo.InvariantCulture) : 0;
+            string lineColor = Escape(SeriesPalette[(barSeriesCount + si) % SeriesPalette.Length]);
+
+            sb.AppendLine($"""  <polyline points="{string.Join(" ", points)}" fill="none" stroke="{lineColor}" stroke-width="{F(theme.StrokeWidth * 1.5)}" stroke-linejoin="round" stroke-linecap="round"/>""");
+        }
+    }
+
     private static void AppendArrowPolygon(StringBuilder sb, double width, double height, string fill, string stroke, Theme theme, string direction)
     {
         double head = Math.Min(width, height) * 0.4;
@@ -348,6 +444,9 @@ public sealed class SvgRenderer : ISvgRenderer
         if (diagram.Nodes.Count == 0)
             return 200;
 
+        if (diagram.Metadata.TryGetValue("xychart:canvasWidth", out var xcW))
+            return Convert.ToDouble(xcW, System.Globalization.CultureInfo.InvariantCulture);
+
         double maxX = diagram.Nodes.Values.Max(n => n.X + n.Width);
         // Group rects extend beyond their member nodes by their own padding;
         // without this, the group's right edge is clipped at the canvas boundary.
@@ -365,6 +464,9 @@ public sealed class SvgRenderer : ISvgRenderer
         // the layout engine stores the required height so node extents don't clip messages.
         if (diagram.Metadata.TryGetValue("sequence:canvasHeight", out var seqH))
             return Convert.ToDouble(seqH, System.Globalization.CultureInfo.InvariantCulture);
+
+        if (diagram.Metadata.TryGetValue("xychart:canvasHeight", out var xcH))
+            return Convert.ToDouble(xcH, System.Globalization.CultureInfo.InvariantCulture);
 
         double maxY = diagram.Nodes.Values.Max(n => n.Y + n.Height);
         if (diagram.Groups.Count > 0)

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="598.00" height="401.00" viewBox="0 0 598.00 401.00">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#555555"/>
+    </marker>
+  </defs>
+  <rect width="598.00" height="401.00" fill="#FFFFFF" rx="8.00" ry="8.00"/>
+  <text x="299.00" y="20.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="15.00" font-weight="bold" fill="#1F2937">Tacos Per Swashbuckler (🌮/🏴‍☠️)</text>
+  <line x1="74.00" y1="47.00" x2="74.00" y2="347.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="74.00" y1="347.00" x2="574.00" y2="347.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="70.00" y1="347.00" x2="74.00" y2="347.00" stroke="#555555" stroke-width="1.50"/>
+  <text x="66.00" y="350.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">0</text>
+  <line x1="70.00" y1="287.00" x2="74.00" y2="287.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="74.00" y1="287.00" x2="574.00" y2="287.00" stroke="#555555" stroke-width="0.5" opacity="0.2"/>
+  <text x="66.00" y="290.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">10</text>
+  <line x1="70.00" y1="227.00" x2="74.00" y2="227.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="74.00" y1="227.00" x2="574.00" y2="227.00" stroke="#555555" stroke-width="0.5" opacity="0.2"/>
+  <text x="66.00" y="230.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">20</text>
+  <line x1="70.00" y1="167.00" x2="74.00" y2="167.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="74.00" y1="167.00" x2="574.00" y2="167.00" stroke="#555555" stroke-width="0.5" opacity="0.2"/>
+  <text x="66.00" y="170.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">30</text>
+  <line x1="70.00" y1="107.00" x2="74.00" y2="107.00" stroke="#555555" stroke-width="1.50"/>
+  <line x1="74.00" y1="107.00" x2="574.00" y2="107.00" stroke="#555555" stroke-width="0.5" opacity="0.2"/>
+  <text x="66.00" y="110.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">40</text>
+  <line x1="70.00" y1="47.00" x2="74.00" y2="47.00" stroke="#555555" stroke-width="1.50"/>
+  <text x="66.00" y="50.87" text-anchor="end" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">50</text>
+  <text x="115.67" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Mon</text>
+  <text x="199.00" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Tue</text>
+  <text x="282.33" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Wed</text>
+  <text x="365.67" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Thu</text>
+  <text x="449.00" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Fri</text>
+  <text x="532.33" y="362.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280">Sat</text>
+  <text x="34.00" y="197.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#6B7280" transform="rotate(-90,34.00,197.00)">TPS Reports Filed</text>
+  <polyline points="115.67,287.00 199.00,275.00 282.33,293.00 365.67,77.00 449.00,263.00 532.33,107.00" fill="none" stroke="#70AD47" stroke-width="2.25" stroke-linejoin="round" stroke-linecap="round"/>
+  <g transform="translate(86.50,299.00)">
+    <rect width="58.33" height="48.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="28.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(169.83,257.00)">
+    <rect width="58.33" height="90.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="49.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(253.17,305.00)">
+    <rect width="58.33" height="42.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="25.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(336.50,95.00)">
+    <rect width="58.33" height="252.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="130.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(419.83,275.00)">
+    <rect width="58.33" height="72.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="40.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(503.17,119.00)">
+    <rect width="58.33" height="228.00" rx="0" ry="0" fill="#4F81BD" stroke="#4F81BD" stroke-width="1.50"/>
+    <text x="29.17" y="118.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(112.67,284.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(196.00,272.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(279.33,290.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(362.67,74.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(446.00,260.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+  <g transform="translate(529.33,104.00)">
+    <ellipse cx="3.00" cy="3.00" rx="3.00" ry="3.00" fill="#70AD47" stroke="#70AD47" stroke-width="1.50"/>
+    <text x="3.00" y="7.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#1F2937"></text>
+  </g>
+</svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.input
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.input
@@ -1,0 +1,6 @@
+xychart-beta
+    title "Tacos Per Swashbuckler (🌮/🏴‍☠️)"
+    x-axis [Mon, Tue, Wed, Thu, Fri, Sat]
+    y-axis "TPS Reports Filed" 0 --> 50
+    bar [8, 15, 7, 42, 12, 38]
+    line [10, 12, 9, 45, 14, 40]

--- a/tests/DiagramForge.Tests/Parsers/Mermaid/MermaidXyChartParserTests.cs
+++ b/tests/DiagramForge.Tests/Parsers/Mermaid/MermaidXyChartParserTests.cs
@@ -1,0 +1,385 @@
+using DiagramForge.Layout;
+using DiagramForge.Models;
+using DiagramForge.Parsers.Mermaid;
+
+namespace DiagramForge.Tests.Parsers.Mermaid;
+
+public class MermaidXyChartParserTests
+{
+    private readonly MermaidParser _parser = new();
+    private readonly DefaultLayoutEngine _layout = new();
+    private readonly Theme _theme = Theme.Default;
+
+    // ── CanParse ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CanParse_ReturnsTrue_ForXyChartBetaHeader()
+    {
+        Assert.True(_parser.CanParse("xychart-beta\n    bar [5000, 6000]"));
+    }
+
+    [Fact]
+    public void CanParse_ReturnsFalse_ForNonMermaidInput()
+    {
+        Assert.False(_parser.CanParse("diagram: process\nsteps:\n  - A"));
+    }
+
+    // ── Title ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_TitleLine_SetsDiagramTitle()
+    {
+        const string input = """
+            xychart-beta
+                title "Sales Revenue"
+                x-axis [jan, feb, mar]
+                bar [5000, 6000, 7500]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        Assert.Equal("Sales Revenue", diagram.Title);
+    }
+
+    [Fact]
+    public void Parse_NoTitleLine_DiagramTitleIsNull()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [jan, feb]
+                bar [100, 200]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        Assert.Null(diagram.Title);
+    }
+
+    // ── X-Axis ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_XAxisCategories_StoresCategories()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [jan, feb, mar, apr]
+                bar [1, 2, 3, 4]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var categories = diagram.Metadata["xychart:categories"] as string[];
+        Assert.NotNull(categories);
+        Assert.Equal(4, categories.Length);
+        Assert.Equal("jan", categories[0]);
+        Assert.Equal("apr", categories[3]);
+    }
+
+    [Fact]
+    public void Parse_XAxisCategories_SetsCategoryCount()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b, c]
+                bar [10, 20, 30]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        Assert.Equal(3, diagram.Metadata["xychart:categoryCount"]);
+    }
+
+    // ── Y-Axis ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_YAxisWithLabelAndRange_StoresBoth()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [jan, feb]
+                y-axis "Revenue (in $)" 4000 --> 11000
+                bar [5000, 6000]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        Assert.Equal("Revenue (in $)", diagram.Metadata["xychart:yLabel"]);
+        Assert.Equal(4000.0, diagram.Metadata["xychart:yMin"]);
+        Assert.Equal(11000.0, diagram.Metadata["xychart:yMax"]);
+    }
+
+    [Fact]
+    public void Parse_YAxisOmitted_AutocomputesRange()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b]
+                bar [100, 500]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        Assert.Equal(0.0, diagram.Metadata["xychart:yMin"]);
+        var yMax = (double)diagram.Metadata["xychart:yMax"];
+        Assert.True(yMax >= 500, $"Expected yMax >= 500, got {yMax}");
+    }
+
+    // ── Bar Series ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_SingleBarSeries_CreatesBarNodes()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b, c]
+                bar [10, 20, 30]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var barNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .ToList();
+
+        Assert.Equal(3, barNodes.Count);
+    }
+
+    [Fact]
+    public void Parse_BarSeriesValues_AreStoredInMetadata()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b]
+                bar [100, 200]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var barNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .OrderBy(n => Convert.ToInt32(n.Metadata["xychart:categoryIndex"], System.Globalization.CultureInfo.InvariantCulture))
+            .ToList();
+
+        Assert.Equal(100.0, barNodes[0].Metadata["xychart:value"]);
+        Assert.Equal(200.0, barNodes[1].Metadata["xychart:value"]);
+    }
+
+    [Fact]
+    public void Parse_MultipleBarSeries_CreatesNodesForEachSeries()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b]
+                bar [10, 20]
+                bar [30, 40]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var barNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .ToList();
+
+        Assert.Equal(4, barNodes.Count);
+        Assert.Equal(2, (int)diagram.Metadata["xychart:barSeriesCount"]);
+    }
+
+    // ── Line Series ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_SingleLineSeries_CreatesLinePointNodes()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b, c]
+                line [10, 20, 30]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var lineNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "linePoint")
+            .ToList();
+
+        Assert.Equal(3, lineNodes.Count);
+    }
+
+    [Fact]
+    public void Parse_LineSeriesValues_AreStoredInMetadata()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b]
+                line [100, 200]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var lineNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "linePoint")
+            .OrderBy(n => Convert.ToInt32(n.Metadata["xychart:categoryIndex"], System.Globalization.CultureInfo.InvariantCulture))
+            .ToList();
+
+        Assert.Equal(100.0, lineNodes[0].Metadata["xychart:value"]);
+        Assert.Equal(200.0, lineNodes[1].Metadata["xychart:value"]);
+    }
+
+    // ── Mixed Series ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_MixedBarAndLine_CreatesAllNodes()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [jan, feb, mar]
+                bar [5000, 6000, 7500]
+                line [5000, 6000, 7000]
+            """;
+
+        var diagram = _parser.Parse(input);
+
+        var barNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .ToList();
+        var lineNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "linePoint")
+            .ToList();
+
+        Assert.Equal(3, barNodes.Count);
+        Assert.Equal(3, lineNodes.Count);
+    }
+
+    // ── DiagramType ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_SetsDiagramType_ToXychart()
+    {
+        var diagram = _parser.Parse("xychart-beta\n    bar [10, 20]");
+
+        Assert.Equal("xychart", diagram.DiagramType);
+        Assert.Equal("mermaid", diagram.SourceSyntax);
+    }
+
+    // ── Layout ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Layout_BarNodes_HavePositiveWidthAndHeight()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b, c]
+                bar [100, 200, 300]
+            """;
+
+        var diagram = _parser.Parse(input);
+        _layout.Layout(diagram, _theme);
+
+        var barNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .ToList();
+
+        Assert.All(barNodes, n =>
+        {
+            Assert.True(n.Width > 0, $"Bar {n.Id} width should be > 0");
+            Assert.True(n.Height > 0, $"Bar {n.Id} height should be > 0");
+        });
+    }
+
+    [Fact]
+    public void Layout_BarNodes_HigherValueProducesTallerBar()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [small, large]
+                bar [100, 500]
+            """;
+
+        var diagram = _parser.Parse(input);
+        _layout.Layout(diagram, _theme);
+
+        var bars = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "bar")
+            .OrderBy(n => Convert.ToInt32(n.Metadata["xychart:categoryIndex"], System.Globalization.CultureInfo.InvariantCulture))
+            .ToList();
+
+        Assert.True(bars[1].Height > bars[0].Height,
+            $"Larger value bar height ({bars[1].Height}) should exceed smaller ({bars[0].Height})");
+    }
+
+    [Fact]
+    public void Layout_LinePoints_ArePositionedWithinChartArea()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b, c]
+                line [10, 20, 30]
+            """;
+
+        var diagram = _parser.Parse(input);
+        _layout.Layout(diagram, _theme);
+
+        var lineNodes = diagram.Nodes.Values
+            .Where(n => n.Metadata.TryGetValue("xychart:kind", out var k) && k is "linePoint")
+            .ToList();
+
+        Assert.All(lineNodes, n =>
+        {
+            Assert.True(n.X >= 0, $"Line point {n.Id} X should be >= 0");
+            Assert.True(n.Y >= 0, $"Line point {n.Id} Y should be >= 0");
+        });
+    }
+
+    [Fact]
+    public void Layout_StoresCanvasDimensions()
+    {
+        const string input = """
+            xychart-beta
+                x-axis [a, b]
+                bar [100, 200]
+            """;
+
+        var diagram = _parser.Parse(input);
+        _layout.Layout(diagram, _theme);
+
+        Assert.True(diagram.Metadata.ContainsKey("xychart:canvasWidth"));
+        Assert.True(diagram.Metadata.ContainsKey("xychart:canvasHeight"));
+        Assert.True((double)diagram.Metadata["xychart:canvasWidth"] > 0);
+        Assert.True((double)diagram.Metadata["xychart:canvasHeight"] > 0);
+    }
+
+    // ── Full pipeline ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FullPipeline_RendersSvgWithBarsAndAxes()
+    {
+        const string input = """
+            xychart-beta
+                title "Sales Revenue"
+                x-axis [jan, feb, mar, apr, may, jun]
+                y-axis "Revenue (in $)" 4000 --> 11000
+                bar [5000, 6000, 7500, 8200, 9500, 10500]
+                line [5000, 6000, 7000, 8000, 9500, 10500]
+            """;
+
+        var renderer = new DiagramRenderer();
+        var svg = renderer.Render(input);
+
+        Assert.StartsWith("<svg", svg);
+        Assert.Contains("</svg>", svg);
+
+        // Should contain bar rects (from AppendNode for Rectangle shapes)
+        Assert.Contains("<rect", svg);
+
+        // Should contain axis lines
+        Assert.Contains("<line", svg);
+
+        // Should contain axis labels
+        Assert.Contains("jan", svg);
+
+        // Should contain the title
+        Assert.Contains("Sales Revenue", svg);
+
+        // Should contain a polyline for the line series
+        Assert.Contains("<polyline", svg);
+    }
+}


### PR DESCRIPTION
- Introduced MermaidDiagramKind.XyChart to represent xychart diagrams.
- Updated MermaidDocument to recognize "xychart-beta" header and parse it accordingly.
- Implemented MermaidXyChartParser to handle parsing of xychart syntax, including title, axes, and data series.
- Enhanced SvgRenderer to render xychart axes, grid lines, and line series.
- Added tests for xychart parsing and rendering, ensuring correct behavior for titles, axes, and series data.
- Created example input and expected output SVG for xychart diagrams.

Closes #22 