### PR TITLE
Polish conceptual pyramid rendering and gallery example

### DIFF
--- a/doc/diagram-gallery.svg
+++ b/doc/diagram-gallery.svg
@@ -101,80 +101,100 @@
   </svg>
   <text x="184" y="342" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="14" fill="#6B7280">Conceptual Matrix</text>
   <rect x="368" y="56" width="320" height="260" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1" rx="8"/>
-  <svg x="368" y="56" width="320" height="260" viewBox="0 0 168.00 328.00" preserveAspectRatio="xMidYMid meet">
+  <svg x="368" y="56" width="320" height="260" viewBox="0 0 292.00 242.00" preserveAspectRatio="xMidYMid meet">
 <defs>
     <marker id="arrowhead-1" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#406B4F"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="168.00" height="328.00" fill="#F6FBF5" rx="8.00" ry="8.00"/>
-  <g transform="translate(24.00,24.00)">
+  <rect width="292.00" height="242.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#E1F4E7"/>
-        <stop offset="58%" stop-color="#DFF3E5"/>
-        <stop offset="100%" stop-color="#D1E4D7"/>
+        <stop offset="0%" stop-color="#E9F1FF"/>
+        <stop offset="58%" stop-color="#E7F0FF"/>
+        <stop offset="100%" stop-color="#D6DEEC"/>
       </linearGradient>
       <linearGradient id="node-0-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Vision</text>
+    <defs>
+      <filter id="node-0-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="114.00,0 139.62,40.00 88.38,40.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Vision</text>
   </g>
-  <g transform="translate(24.00,104.00)">
+  <g transform="translate(32.00,78.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#CFEBD3"/>
-        <stop offset="58%" stop-color="#CBEACF"/>
-        <stop offset="100%" stop-color="#BEDBC2"/>
+        <stop offset="0%" stop-color="#FFE8DC"/>
+        <stop offset="58%" stop-color="#FFE6D8"/>
+        <stop offset="100%" stop-color="#ECD5C8"/>
       </linearGradient>
       <linearGradient id="node-1-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Strategy</text>
+    <defs>
+      <filter id="node-1-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="84.54,0 143.46,0 169.08,40.00 58.92,40.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Strategy</text>
   </g>
-  <g transform="translate(24.00,184.00)">
+  <g transform="translate(32.00,124.00)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#BCE3C3"/>
-        <stop offset="58%" stop-color="#B6E1BE"/>
-        <stop offset="100%" stop-color="#ABD3B2"/>
+        <stop offset="0%" stop-color="#FFF1CD"/>
+        <stop offset="58%" stop-color="#FFF0C7"/>
+        <stop offset="100%" stop-color="#ECDEB8"/>
       </linearGradient>
       <linearGradient id="node-2-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Tactics</text>
+    <defs>
+      <filter id="node-2-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="55.08,0 172.92,0 198.54,40.00 29.46,40.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Tactics</text>
   </g>
-  <g transform="translate(24.00,264.00)">
+  <g transform="translate(32.00,170.00)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#ABDBB7"/>
-        <stop offset="58%" stop-color="#A3D8B0"/>
-        <stop offset="100%" stop-color="#99CBA5"/>
+        <stop offset="0%" stop-color="#DFF6EA"/>
+        <stop offset="58%" stop-color="#DCF5E8"/>
+        <stop offset="100%" stop-color="#CCE3D7"/>
       </linearGradient>
       <linearGradient id="node-3-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Execution</text>
+    <defs>
+      <filter id="node-3-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="25.62,0 202.38,0 228.00,40.00 0.00,40.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Execution</text>
   </g>
   </svg>
   <text x="528" y="342" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="14" fill="#6B7280">Conceptual Pyramid</text>

--- a/src/DiagramForge/Layout/DefaultLayoutEngine.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.cs
@@ -26,6 +26,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     // nodeSpacing/rankSpacing (50/50) so bezier edges have room.
     private const double BlockHGapWide = 50;
     private const double BlockVGapWide = 40;
+    private const double PyramidLevelGap = 6;
 
     /// <summary>
     /// Average glyph advance as a fraction of font size (em-units) for typical
@@ -82,6 +83,12 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         if (string.Equals(diagram.DiagramType, "venn", StringComparison.OrdinalIgnoreCase))
         {
             LayoutVennDiagram(diagram, theme, minW, pad);
+            return;
+        }
+
+        if (string.Equals(diagram.DiagramType, "pyramid", StringComparison.OrdinalIgnoreCase))
+        {
+            LayoutPyramidDiagram(diagram, theme, minW, nodeH, pad);
             return;
         }
         
@@ -450,6 +457,48 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
 
         // Shift whole diagram if any group extends into negative space.
         ShiftDiagramForGroupPadding(diagram, theme.DiagramPadding);
+    }
+
+    private static void LayoutPyramidDiagram(
+        Diagram diagram,
+        Theme theme,
+        double minW,
+        double nodeH,
+        double pad)
+    {
+        var orderedNodes = diagram.Nodes.Values
+            .OrderBy(node => node.Id, StringComparer.Ordinal)
+            .ToList();
+
+        if (orderedNodes.Count == 0)
+            return;
+
+        double widestLabel = orderedNodes.Max(node =>
+        {
+            double fontSize = node.Label.FontSize ?? theme.FontSize;
+            return EstimateTextWidth(node.Label.Text, fontSize) + 2 * theme.NodePadding;
+        });
+
+        int levelCount = orderedNodes.Count;
+        double bottomWidth = Math.Max(widestLabel, minW * 1.9);
+        double totalHeight = levelCount * nodeH + (levelCount - 1) * PyramidLevelGap;
+
+        for (int index = 0; index < orderedNodes.Count; index++)
+        {
+            var node = orderedNodes[index];
+            double yTop = index * (nodeH + PyramidLevelGap);
+            double yBottom = yTop + nodeH;
+            double topWidth = bottomWidth * yTop / totalHeight;
+            double segmentBottomWidth = bottomWidth * yBottom / totalHeight;
+
+            node.X = pad;
+            node.Y = pad + yTop;
+            node.Width = bottomWidth;
+            node.Height = nodeH;
+            node.Metadata["conceptual:pyramidSegment"] = true;
+            node.Metadata["conceptual:pyramidTopWidth"] = topWidth;
+            node.Metadata["conceptual:pyramidBottomWidth"] = segmentBottomWidth;
+        }
     }
 
     private static void LayoutSequenceDiagram(

--- a/src/DiagramForge/Rendering/SvgRenderer.cs
+++ b/src/DiagramForge/Rendering/SvgRenderer.cs
@@ -144,6 +144,14 @@ public sealed class SvgRenderer : ISvgRenderer
 
         if (!textOnly)
         {
+            if (node.Metadata.TryGetValue("conceptual:pyramidSegment", out var pyramidSegmentObj)
+                && pyramidSegmentObj is bool isPyramidSegment
+                && isPyramidSegment)
+            {
+                AppendPyramidSegmentNode(sb, node, fill, stroke, theme, fillOpacityAttribute, nodeShadowAttribute);
+            }
+            else
+            {
             switch (node.Shape)
             {
                 case Shape.Circle:
@@ -181,6 +189,7 @@ public sealed class SvgRenderer : ISvgRenderer
                 default:
                     AppendRoundedRectNode(sb, node, fill, stroke, theme, fillOpacityAttribute, rx, nodeShadowAttribute);
                     break;
+            }
             }
         }
         else if (HasTextOnlyBackdrop(node, fillOpacity))
@@ -499,6 +508,20 @@ public sealed class SvgRenderer : ISvgRenderer
         double mx = node.Width / 2;
         double my = node.Height / 2;
         sb.AppendLine($"""    <polygon points="{F(mx)},0 {F(node.Width)},{F(my)} {F(mx)},{F(node.Height)} 0,{F(my)}" fill="{fill}" stroke="{stroke}" stroke-width="{F(theme.StrokeWidth)}"{fillOpacityAttribute}{shadowAttribute}/>""");
+    }
+
+    private static void AppendPyramidSegmentNode(StringBuilder sb, Node node, string fill, string stroke, Theme theme, string fillOpacityAttribute, string shadowAttribute)
+    {
+        double topWidth = GetMetadataDouble(node, "conceptual:pyramidTopWidth") ?? 0;
+        double bottomWidth = GetMetadataDouble(node, "conceptual:pyramidBottomWidth") ?? node.Width;
+        double topInset = (node.Width - topWidth) / 2;
+        double bottomInset = (node.Width - bottomWidth) / 2;
+
+        string points = topWidth <= 0.01
+            ? $"{F(node.Width / 2)},0 {F(bottomInset + bottomWidth)},{F(node.Height)} {F(bottomInset)},{F(node.Height)}"
+            : $"{F(topInset)},0 {F(topInset + topWidth)},0 {F(bottomInset + bottomWidth)},{F(node.Height)} {F(bottomInset)},{F(node.Height)}";
+
+        sb.AppendLine($"""    <polygon points="{points}" fill="{fill}" stroke="{stroke}" stroke-width="{F(theme.StrokeWidth)}"{fillOpacityAttribute}{shadowAttribute}/>""");
     }
 
     private static void AppendRoundedRectNode(StringBuilder sb, Node node, string fill, string stroke, Theme theme, string fillOpacityAttribute, double radius, string shadowAttribute)

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg
@@ -1,76 +1,96 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="168.00" height="328.00" viewBox="0 0 168.00 328.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="292.00" height="242.00" viewBox="0 0 292.00 242.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#406B4F"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="168.00" height="328.00" fill="#F6FBF5" rx="8.00" ry="8.00"/>
-  <g transform="translate(24.00,24.00)">
+  <rect width="292.00" height="242.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#E1F4E7"/>
-        <stop offset="58%" stop-color="#DFF3E5"/>
-        <stop offset="100%" stop-color="#D1E4D7"/>
+        <stop offset="0%" stop-color="#E9F1FF"/>
+        <stop offset="58%" stop-color="#E7F0FF"/>
+        <stop offset="100%" stop-color="#D6DEEC"/>
       </linearGradient>
       <linearGradient id="node-0-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Vision</text>
+    <defs>
+      <filter id="node-0-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="114.00,0 139.62,40.00 88.38,40.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Vision</text>
   </g>
-  <g transform="translate(24.00,104.00)">
+  <g transform="translate(32.00,78.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#CFEBD3"/>
-        <stop offset="58%" stop-color="#CBEACF"/>
-        <stop offset="100%" stop-color="#BEDBC2"/>
+        <stop offset="0%" stop-color="#FFE8DC"/>
+        <stop offset="58%" stop-color="#FFE6D8"/>
+        <stop offset="100%" stop-color="#ECD5C8"/>
       </linearGradient>
       <linearGradient id="node-1-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Strategy</text>
+    <defs>
+      <filter id="node-1-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="84.54,0 143.46,0 169.08,40.00 58.92,40.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Strategy</text>
   </g>
-  <g transform="translate(24.00,184.00)">
+  <g transform="translate(32.00,124.00)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#BCE3C3"/>
-        <stop offset="58%" stop-color="#B6E1BE"/>
-        <stop offset="100%" stop-color="#ABD3B2"/>
+        <stop offset="0%" stop-color="#FFF1CD"/>
+        <stop offset="58%" stop-color="#FFF0C7"/>
+        <stop offset="100%" stop-color="#ECDEB8"/>
       </linearGradient>
       <linearGradient id="node-2-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Tactics</text>
+    <defs>
+      <filter id="node-2-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="55.08,0 172.92,0 198.54,40.00 29.46,40.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Tactics</text>
   </g>
-  <g transform="translate(24.00,264.00)">
+  <g transform="translate(32.00,170.00)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#ABDBB7"/>
-        <stop offset="58%" stop-color="#A3D8B0"/>
-        <stop offset="100%" stop-color="#99CBA5"/>
+        <stop offset="0%" stop-color="#DFF6EA"/>
+        <stop offset="58%" stop-color="#DCF5E8"/>
+        <stop offset="100%" stop-color="#CCE3D7"/>
       </linearGradient>
       <linearGradient id="node-3-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-        <stop offset="0%" stop-color="#B9C9BD"/>
-        <stop offset="33%" stop-color="#99BB9F"/>
-        <stop offset="67%" stop-color="#C0CBB0"/>
-        <stop offset="100%" stop-color="#9EBFAD"/>
+        <stop offset="0%" stop-color="#C0C6D3"/>
+        <stop offset="33%" stop-color="#D3C6A6"/>
+        <stop offset="67%" stop-color="#B9C8D3"/>
+        <stop offset="100%" stop-color="#C1CAC1"/>
       </linearGradient>
     </defs>
-    <rect width="120.00" height="40.00" rx="8.00" ry="8.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.50"/>
-    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#16311F">Execution</text>
+    <defs>
+      <filter id="node-3-soft-shadow" x="-8%" y="-8%" width="124%" height="136%" color-interpolation-filters="sRGB">
+        <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
+      </filter>
+    </defs>
+    <polygon points="25.62,0 202.38,0 228.00,40.00 0.00,40.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="114.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Execution</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.input
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.input
@@ -1,5 +1,5 @@
 ---
-theme: forest
+theme: presentation
 ---
 diagram: pyramid
 levels:

--- a/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
+++ b/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
@@ -246,6 +246,32 @@ public class DefaultLayoutEngineTests
     }
 
     [Fact]
+    public void Layout_Pyramid_AssignsTriangularSegmentMetadata()
+    {
+        var diagram = new Diagram { DiagramType = "pyramid" };
+        diagram.AddNode(new Node("node_0", "Vision"))
+               .AddNode(new Node("node_1", "Strategy"))
+               .AddNode(new Node("node_2", "Tactics"))
+               .AddNode(new Node("node_3", "Execution"));
+
+        _engine.Layout(diagram, _theme);
+
+        var top = diagram.Nodes["node_0"];
+        var second = diagram.Nodes["node_1"];
+        var bottom = diagram.Nodes["node_3"];
+
+        Assert.Equal(top.X, bottom.X);
+        Assert.True(top.Y < bottom.Y);
+        Assert.True(second.Y > top.Y + top.Height,
+            $"Expected a visible gap between pyramid levels, but second.Y ({second.Y}) was not greater than top bottom ({top.Y + top.Height}).");
+        Assert.Equal(0d, Convert.ToDouble(top.Metadata["conceptual:pyramidTopWidth"], System.Globalization.CultureInfo.InvariantCulture));
+        Assert.True(
+            Convert.ToDouble(bottom.Metadata["conceptual:pyramidBottomWidth"], System.Globalization.CultureInfo.InvariantCulture)
+            > Convert.ToDouble(top.Metadata["conceptual:pyramidBottomWidth"], System.Globalization.CultureInfo.InvariantCulture));
+        Assert.All(diagram.Nodes.Values, node => Assert.True((bool)node.Metadata["conceptual:pyramidSegment"]));
+    }
+
+    [Fact]
     public void Layout_VennDiagram_PositionsNestedTextNodesUnderSetsAndUnion()
     {
         var diagram = new Diagram { DiagramType = "venn" };

--- a/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
+++ b/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
@@ -255,6 +255,26 @@ public class SvgRendererTests
         Assert.DoesNotContain("<rect width=\"0.00\" height=\"0.00\"", svg);
     }
 
+    [Fact]
+    public void Render_PyramidSegmentNode_UsesPolygon()
+    {
+        var node = new Node("node_0", "Vision")
+        {
+            Width = 180,
+            Height = 60,
+        };
+        node.Metadata["conceptual:pyramidSegment"] = true;
+        node.Metadata["conceptual:pyramidTopWidth"] = 0d;
+        node.Metadata["conceptual:pyramidBottomWidth"] = 90d;
+
+        var diagram = new Diagram().AddNode(node);
+
+        string svg = _renderer.Render(diagram, _theme);
+
+        Assert.Contains("<polygon points=", svg);
+        Assert.Contains(">Vision</text>", svg);
+    }
+
     // ── Utilities (mirrors the production SvgRenderer.F() helper) ────────────
 
     private static string F(double v) =>


### PR DESCRIPTION
## Summary
- render conceptual pyramids as true triangular stacked segments instead of rectangular boxes
- add small spacing between pyramid levels while preserving the overall silhouette
- switch the gallery pyramid fixture to the colorful `presentation` theme and rebuild the diagram gallery
- add focused layout and renderer tests for pyramid segment geometry

## Testing
- dotnet test tests/DiagramForge.Tests/DiagramForge.Tests.csproj --filter "Layout_Pyramid_AssignsTriangularSegmentMetadata|Render_PyramidSegmentNode_UsesPolygon" -v minimal
- dotnet test tests/DiagramForge.E2ETests/DiagramForge.E2ETests.csproj -v minimal
- ./scripts/Build-Gallery.ps1
