### PR TITLE
Refine conceptual matrix into 2x2 quadrants

### DIFF
--- a/doc/diagram-gallery.svg
+++ b/doc/diagram-gallery.svg
@@ -3,13 +3,13 @@
   <rect width="100%" height="100%" fill="#F8FAFC" rx="12"/>
   <text x="700" y="36" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="20" font-weight="bold" fill="#1F2937">DiagramForge - Diagram Gallery</text>
   <rect x="24" y="56" width="320" height="260" fill="#FFFFFF" stroke="#E5E7EB" stroke-width="1" rx="8"/>
-  <svg x="24" y="56" width="320" height="260" viewBox="0 0 345.60 344.00" preserveAspectRatio="xMidYMid meet">
+  <svg x="24" y="56" width="320" height="260" viewBox="0 0 411.60 238.80" preserveAspectRatio="xMidYMid meet">
 <defs>
     <marker id="arrowhead-0" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="345.60" height="344.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <rect width="411.60" height="238.80" fill="#FFFDF8" rx="12.00" ry="12.00"/>
   <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -29,10 +29,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="204.80" height="40.00" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="102.40" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Important / Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,112.00)">
+  <g transform="translate(214.80,32.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFE8DC"/>
@@ -51,10 +54,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="243.20" height="40.00" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="121.60" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Important / Not Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Not Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,192.00)">
+  <g transform="translate(32.00,128.40)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFF1CD"/>
@@ -73,10 +79,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="243.20" height="40.00" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="121.60" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Not Important / Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Not Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,272.00)">
+  <g transform="translate(214.80,128.40)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#DFF6EA"/>
@@ -95,8 +104,11 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="281.60" height="40.00" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="140.80" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Not Important / Not Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Not Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Not Important</tspan>
+    </text>
   </g>
   </svg>
   <text x="184" y="342" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="14" fill="#6B7280">Conceptual Matrix</text>

--- a/doc/parser-architecture.md
+++ b/doc/parser-architecture.md
@@ -215,7 +215,7 @@ directly on trimmed lines:
 | Diagram type | Section key | Structure |
 |-------------|------------|-----------|
 | `pyramid` | `levels:` | Nodes only |
-| `matrix` | `rows:` + `columns:` | Grid of `cell_{r}_{c}` nodes |
+| `matrix` | `rows:` + `columns:` | Specialized 2×2 quadrant nodes (`cell_{r}_{c}`) |
 
 The parser sets `LayoutDirection` to `LeftToRight` for all types.
 

--- a/doc/testing-strategy.md
+++ b/doc/testing-strategy.md
@@ -226,7 +226,7 @@ dotnet test --collect:"XPlat Code Coverage"
 | `conceptual-cycle` | Conceptual | cycle | Back-edge from last to first |
 | `conceptual-hierarchy` | Conceptual | hierarchy | Indent-based tree |
 | `conceptual-list` | Conceptual | list | Nodes only, no edges |
-| `conceptual-matrix` | Conceptual | matrix | Row × column grid |
+| `conceptual-matrix` | Conceptual | matrix | Specialized 2×2 quadrant layout |
 | `conceptual-process` | Conceptual | process | Linear chain with edges |
 | `conceptual-pyramid` | Conceptual | pyramid | Nodes only |
 | `mermaid-comments` | Mermaid | flowchart | `%%` comment stripping |

--- a/src/DiagramForge/Layout/DefaultLayoutEngine.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.cs
@@ -86,6 +86,12 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             return;
         }
 
+        if (string.Equals(diagram.DiagramType, "matrix", StringComparison.OrdinalIgnoreCase))
+        {
+            LayoutMatrixDiagram(diagram, theme, minW, nodeH, pad);
+            return;
+        }
+
         if (string.Equals(diagram.DiagramType, "pyramid", StringComparison.OrdinalIgnoreCase))
         {
             LayoutPyramidDiagram(diagram, theme, minW, nodeH, pad);
@@ -903,6 +909,56 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         }
     }
 
+    private static void LayoutMatrixDiagram(
+        Diagram diagram,
+        Theme theme,
+        double minW,
+        double nodeH,
+        double pad)
+    {
+        var cells = diagram.Nodes.Values
+            .Where(node => node.Metadata.ContainsKey("matrix:row") && node.Metadata.ContainsKey("matrix:column"))
+            .OrderBy(node => GetMetadataInt(node.Metadata, "matrix:row"))
+            .ThenBy(node => GetMetadataInt(node.Metadata, "matrix:column"))
+            .ToList();
+
+        if (cells.Count == 0)
+            return;
+
+        double titleOffset = !string.IsNullOrWhiteSpace(diagram.Title) ? theme.TitleFontSize + 8 : 0;
+        double baseFontSize = cells.Max(node => node.Label.FontSize ?? theme.FontSize);
+        int maxLineCount = cells.Max(node => GetTextLineCount(node.Label.Text));
+        double maxTextWidth = cells.Max(node => EstimateTextWidth(node.Label.Text, node.Label.FontSize ?? theme.FontSize));
+
+        double cellWidth = Math.Max(minW + 24, maxTextWidth + theme.NodePadding * 2.5);
+        double textBlockHeight = Math.Max(1, maxLineCount) * baseFontSize * 1.15;
+        double cellHeight = Math.Max(nodeH + baseFontSize * 0.7, textBlockHeight + theme.NodePadding * 2.6);
+        double gap = Math.Max(theme.NodePadding, 18);
+
+        string[] palette = theme.NodePalette is { Count: > 0 }
+            ? [.. theme.NodePalette]
+            : [theme.NodeFillColor, theme.NodeFillColor, theme.NodeFillColor, theme.NodeFillColor];
+
+        foreach (var cell in cells)
+        {
+            int row = GetMetadataInt(cell.Metadata, "matrix:row");
+            int column = GetMetadataInt(cell.Metadata, "matrix:column");
+            int paletteIndex = Math.Clamp(row * 2 + column, 0, palette.Length - 1);
+            string fill = palette[paletteIndex];
+
+            cell.Shape = Shape.RoundedRectangle;
+            cell.Width = cellWidth;
+            cell.Height = cellHeight;
+            cell.X = pad + column * (cellWidth + gap);
+            cell.Y = pad + titleOffset + row * (cellHeight + gap);
+            cell.FillColor = fill;
+            cell.StrokeColor = theme.NodeStrokePalette is { Count: > 0 }
+                ? theme.NodeStrokePalette[paletteIndex % theme.NodeStrokePalette.Count]
+                : ColorUtils.Darken(fill, 0.18);
+            SetLabelCenter(cell, cellWidth / 2, cellHeight / 2);
+        }
+    }
+
     private static void SetLabelCenter(Node node, double x, double y)
     {
         node.Metadata["label:centerX"] = x;
@@ -1047,7 +1103,19 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     {
         if (string.IsNullOrEmpty(text))
             return 0;
-        return text.Length * fontSize * AvgGlyphAdvanceEm;
+
+        return text
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Split('\n')
+            .Max(line => line.Length) * fontSize * AvgGlyphAdvanceEm;
+    }
+
+    private static int GetTextLineCount(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return 0;
+
+        return text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n').Length;
     }
 
     /// <summary>

--- a/src/DiagramForge/Parsers/Conceptual/ConceptualDslParser.cs
+++ b/src/DiagramForge/Parsers/Conceptual/ConceptualDslParser.cs
@@ -105,14 +105,6 @@ public sealed class ConceptualDslParser : IDiagramParser
 
     private static void ParseMatrixDiagram(string[] lines, IDiagramSemanticModelBuilder builder)
     {
-        // Expected format:
-        //   rows:
-        //     - Row A
-        //     - Row B
-        //   columns:
-        //     - Col 1
-        //     - Col 2
-
         int rowsLine = FindSectionLine(lines, "rows");
         int colsLine = FindSectionLine(lines, "columns");
 
@@ -122,13 +114,20 @@ public sealed class ConceptualDslParser : IDiagramParser
         if (rows.Count == 0 || cols.Count == 0)
             throw new DiagramParseException("Matrix diagram requires non-empty 'rows' and 'columns' sections.");
 
+        if (rows.Count != 2 || cols.Count != 2)
+            throw new DiagramParseException("Matrix diagram currently supports exactly 2 rows and 2 columns.");
+
         for (int r = 0; r < rows.Count; r++)
         {
             for (int c = 0; c < cols.Count; c++)
             {
                 var nodeId = $"cell_{r}_{c}";
-                var label = $"{rows[r]} / {cols[c]}";
-                builder.AddNode(new Node(nodeId, label));
+                var node = new Node(nodeId, $"{cols[c]}\n{rows[r]}");
+                node.Metadata["matrix:row"] = r;
+                node.Metadata["matrix:column"] = c;
+                node.Metadata["matrix:rowLabel"] = rows[r];
+                node.Metadata["matrix:columnLabel"] = cols[c];
+                builder.AddNode(node);
             }
         }
 

--- a/src/DiagramForge/Rendering/SvgRenderer.cs
+++ b/src/DiagramForge/Rendering/SvgRenderer.cs
@@ -211,9 +211,8 @@ public sealed class SvgRenderer : ISvgRenderer
             double fontSize = node.Label.FontSize ?? theme.FontSize;
             double textX = GetMetadataDouble(node, "label:centerX") ?? (textOnly ? 0 : (node.Width / 2));
             double textBaselineY = GetMetadataDouble(node, "label:centerY") ?? (textOnly ? 0 : (node.Height / 2));
-            double textY = textBaselineY + fontSize * 0.35;
 
-            sb.AppendLine($"""    <text x="{F(textX)}" y="{F(textY)}" text-anchor="middle" font-family="{Escape(theme.FontFamily)}" font-size="{F(fontSize)}" fill="{textColor}">{Escape(node.Label.Text)}</text>""");
+            AppendNodeLabel(sb, node.Label.Text, theme, textX, textBaselineY, fontSize, textColor);
         }
         sb.AppendLine("  </g>");
     }
@@ -602,7 +601,40 @@ public sealed class SvgRenderer : ISvgRenderer
         if (string.IsNullOrEmpty(text))
             return 0;
 
-        return text.Length * fontSize * AvgGlyphAdvanceEm;
+        return text
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Split('\n')
+            .Max(line => line.Length) * fontSize * AvgGlyphAdvanceEm;
+    }
+
+    private static void AppendNodeLabel(
+        StringBuilder sb,
+        string labelText,
+        Theme theme,
+        double centerX,
+        double centerY,
+        double fontSize,
+        string textColor)
+    {
+        var lines = labelText.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n');
+        double lineHeight = fontSize * 1.15;
+        double firstBaselineY = centerY + fontSize * 0.35 - ((lines.Length - 1) * lineHeight / 2);
+
+        if (lines.Length == 1)
+        {
+            sb.AppendLine($"""    <text x="{F(centerX)}" y="{F(firstBaselineY)}" text-anchor="middle" font-family="{Escape(theme.FontFamily)}" font-size="{F(fontSize)}" fill="{textColor}">{Escape(lines[0])}</text>""");
+            return;
+        }
+
+        sb.AppendLine($"""    <text x="{F(centerX)}" y="{F(firstBaselineY)}" text-anchor="middle" font-family="{Escape(theme.FontFamily)}" font-size="{F(fontSize)}" fill="{textColor}">""");
+        sb.AppendLine($"""      <tspan x="{F(centerX)}" y="{F(firstBaselineY)}">{Escape(lines[0])}</tspan>""");
+
+        for (int i = 1; i < lines.Length; i++)
+        {
+            sb.AppendLine($"""      <tspan x="{F(centerX)}" dy="{F(lineHeight)}">{Escape(lines[i])}</tspan>""");
+        }
+
+        sb.AppendLine("    </text>");
     }
 
     private static bool TryResolveXyChartColors(Node node, Theme theme, out string fillColor, out string strokeColor)

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="345.60" height="344.00" viewBox="0 0 345.60 344.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="411.60" height="238.80" viewBox="0 0 411.60 238.80">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="345.60" height="344.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <rect width="411.60" height="238.80" fill="#FFFDF8" rx="12.00" ry="12.00"/>
   <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -24,10 +24,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="204.80" height="40.00" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="102.40" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Important / Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,112.00)">
+  <g transform="translate(214.80,32.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFE8DC"/>
@@ -46,10 +49,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="243.20" height="40.00" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="121.60" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Important / Not Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Not Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,192.00)">
+  <g transform="translate(32.00,128.40)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFF1CD"/>
@@ -68,10 +74,13 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="243.20" height="40.00" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="121.60" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Not Important / Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Not Important</tspan>
+    </text>
   </g>
-  <g transform="translate(32.00,272.00)">
+  <g transform="translate(214.80,128.40)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#DFF6EA"/>
@@ -90,7 +99,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="281.60" height="40.00" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="140.80" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Not Important / Not Urgent</text>
+    <rect width="164.80" height="78.40" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="82.40" y="35.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">
+      <tspan x="82.40" y="35.60">Not Urgent</tspan>
+      <tspan x="82.40" dy="18.40">Not Important</tspan>
+    </text>
   </g>
 </svg>

--- a/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
+++ b/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
@@ -8,6 +8,14 @@ public class DefaultLayoutEngineTests
     private readonly DefaultLayoutEngine _engine = new();
     private readonly Theme _theme = Theme.Default;
 
+    private static Node MatrixCell(string id, string label, int row, int column)
+    {
+        var node = new Node(id, label);
+        node.Metadata["matrix:row"] = row;
+        node.Metadata["matrix:column"] = column;
+        return node;
+    }
+
     [Fact]
     public void Layout_SingleNode_AssignsNonNegativePosition()
     {
@@ -243,6 +251,32 @@ public class DefaultLayoutEngineTests
             $"Expected two-set overlap label X ({overlap.X}) to fall between the circles.");
         Assert.True(overlap.Y > left.Y && overlap.Y < left.Y + left.Height,
             $"Expected two-set overlap label Y ({overlap.Y}) to remain inside the overlapping band.");
+    }
+
+    [Fact]
+    public void Layout_MatrixDiagram_PlacesQuadrantsInTwoByTwoGrid()
+    {
+        var diagram = new Diagram { DiagramType = "matrix" };
+
+        diagram.AddNode(MatrixCell("cell_0_0", "Urgent\nImportant", 0, 0))
+               .AddNode(MatrixCell("cell_0_1", "Not Urgent\nImportant", 0, 1))
+               .AddNode(MatrixCell("cell_1_0", "Urgent\nNot Important", 1, 0))
+               .AddNode(MatrixCell("cell_1_1", "Not Urgent\nNot Important", 1, 1));
+
+        _engine.Layout(diagram, _theme);
+
+        var topLeft = diagram.Nodes["cell_0_0"];
+        var topRight = diagram.Nodes["cell_0_1"];
+        var bottomLeft = diagram.Nodes["cell_1_0"];
+        var bottomRight = diagram.Nodes["cell_1_1"];
+
+        Assert.Equal(topLeft.Width, topRight.Width);
+        Assert.Equal(topLeft.Height, bottomLeft.Height);
+        Assert.True(topLeft.X < topRight.X);
+        Assert.True(topLeft.Y < bottomLeft.Y);
+        Assert.True(bottomLeft.X < bottomRight.X);
+        Assert.Equal(topLeft.Width / 2, Convert.ToDouble(topLeft.Metadata["label:centerX"], System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(topLeft.Height / 2, Convert.ToDouble(topLeft.Metadata["label:centerY"], System.Globalization.CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/tests/DiagramForge.Tests/Parsers/ConceptualDslParserTests.cs
+++ b/tests/DiagramForge.Tests/Parsers/ConceptualDslParserTests.cs
@@ -39,7 +39,7 @@ public class ConceptualDslParserTests
     // ── Matrix ────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Parse_Matrix_ProducesRowsTimesColumnsNodes()
+    public void Parse_Matrix_ProducesFourQuadrantNodes()
     {
         const string text = """
             diagram: matrix
@@ -53,7 +53,28 @@ public class ConceptualDslParserTests
 
         var diagram = _parser.Parse(text);
 
-        Assert.Equal(4, diagram.Nodes.Count); // 2×2
+        Assert.Equal(4, diagram.Nodes.Count);
+        Assert.Equal("Col 1\nRow A", diagram.Nodes["cell_0_0"].Label.Text);
+        Assert.Equal(0, diagram.Nodes["cell_0_0"].Metadata["matrix:row"]);
+        Assert.Equal(0, diagram.Nodes["cell_0_0"].Metadata["matrix:column"]);
+        Assert.Equal("Col 2\nRow B", diagram.Nodes["cell_1_1"].Label.Text);
+    }
+
+    [Fact]
+    public void Parse_Matrix_RequiresExactlyTwoRowsAndTwoColumns()
+    {
+        const string text = """
+            diagram: matrix
+            rows:
+              - Row A
+            columns:
+              - Col 1
+              - Col 2
+            """;
+
+        var ex = Assert.Throws<DiagramParseException>(() => _parser.Parse(text));
+
+        Assert.Contains("exactly 2 rows and 2 columns", ex.Message);
     }
 
     // ── Pyramid ───────────────────────────────────────────────────────────────
@@ -73,7 +94,7 @@ public class ConceptualDslParserTests
     [Fact]
     public void Parse_SourceSyntax_IsConceptual()
     {
-        var diagram = _parser.Parse("diagram: matrix\nrows:\n  - X\ncolumns:\n  - Y");
+        var diagram = _parser.Parse("diagram: matrix\nrows:\n  - X\n  - Y\ncolumns:\n  - A\n  - B");
 
         Assert.Equal("conceptual", diagram.SourceSyntax);
     }

--- a/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
+++ b/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
@@ -256,6 +256,19 @@ public class SvgRendererTests
     }
 
     [Fact]
+    public void Render_MultilineLabel_UsesTspans()
+    {
+        var diagram = BuildAndLayout(new Diagram()
+            .AddNode(new Node("A", "Urgent\nImportant")));
+
+        string svg = _renderer.Render(diagram, _theme);
+
+        Assert.Contains("<tspan", svg);
+        Assert.Contains(">Urgent</tspan>", svg);
+        Assert.Contains(">Important</tspan>", svg);
+    }
+
+    [Fact]
     public void Render_PyramidSegmentNode_UsesPolygon()
     {
         var node = new Node("node_0", "Vision")


### PR DESCRIPTION
## Summary
- restrict conceptual `matrix` diagrams to an intentional 2x2 quadrant format
- add dedicated matrix layout and multiline SVG label rendering for cleaner quadrant tiles
- update parser/layout/renderer tests, snapshot baseline, docs, and the generated diagram gallery

## Validation
- `dotnet test tests/DiagramForge.Tests/DiagramForge.Tests.csproj --filter "FullyQualifiedName~ConceptualDslParserTests|FullyQualifiedName~DefaultLayoutEngineTests|FullyQualifiedName~SvgRendererTests" --no-restore --verbosity minimal`
- `dotnet test tests/DiagramForge.E2ETests/DiagramForge.E2ETests.csproj --filter "FullyQualifiedName~SnapshotTests&DisplayName~conceptual-matrix" --no-restore --verbosity minimal`
