### PR TITLE
Improve parser performance and add benchmarks

### DIFF
--- a/DiagramForge.slnx
+++ b/DiagramForge.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/DiagramForge.Benchmarks/DiagramForge.Benchmarks.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/DiagramForge.Cli/DiagramForge.Cli.csproj" />
     <Project Path="src/DiagramForge/DiagramForge.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
 
   <!-- Test project packages -->
   <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <!-- xUnit v3 (Apache-2.0) — includes Microsoft Testing Platform (MTP) runner -->
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <!-- Code coverage (MIT) -->

--- a/benchmarks/DiagramForge.Benchmarks/DiagramForge.Benchmarks.csproj
+++ b/benchmarks/DiagramForge.Benchmarks/DiagramForge.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DiagramForge\DiagramForge.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/benchmarks/DiagramForge.Benchmarks/Program.cs
+++ b/benchmarks/DiagramForge.Benchmarks/Program.cs
@@ -1,0 +1,49 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+using DiagramForge;
+
+BenchmarkRunner.Run<RendererBenchmarks>();
+
+[MemoryDiagnoser]
+public class RendererBenchmarks
+{
+    private readonly DiagramRenderer _renderer = new();
+
+    private const string ConceptualMatrix = """
+        diagram: matrix
+        rows:
+          - Important
+          - Not Important
+        columns:
+          - Urgent
+          - Not Urgent
+        """;
+
+    private const string MermaidFlowchart = """
+        flowchart LR
+          A[Collect] --> B[Shape]
+          B --> C{Review}
+          C -->|approved| D[Ship]
+          C -->|changes| B
+        """;
+
+    private const string MermaidXyChart = """
+        xychart-beta
+          title "Quarterly Revenue"
+          x-axis [Q1, Q2, Q3, Q4]
+          y-axis "Revenue" 200 --> 360
+          bar [208, 262, 314, 298]
+          bar [235, 295, 352, 330]
+          line [220, 280, 332, 310]
+        """;
+
+    [Benchmark]
+    public string RenderConceptualMatrix() => _renderer.Render(ConceptualMatrix);
+
+    [Benchmark]
+    public string RenderMermaidFlowchart() => _renderer.Render(MermaidFlowchart);
+
+    [Benchmark]
+    public string RenderMermaidXyChart() => _renderer.Render(MermaidXyChart);
+}

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -1,0 +1,21 @@
+# Performance Notes
+
+This repository uses a few targeted modern .NET features where they pay off without adding parser complexity:
+
+- System.Text.Json source generation for theme and palette serialization
+- generated regular expressions for Mermaid parsers
+- lower-allocation line and CSV scanning in parser hot paths
+
+## Benchmarks
+
+Run the BenchmarkDotNet project to measure end-to-end render throughput and allocations for representative diagrams:
+
+```sh
+dotnet run -c Release --project benchmarks/DiagramForge.Benchmarks/DiagramForge.Benchmarks.csproj
+```
+
+The current benchmark suite covers:
+
+- conceptual 2x2 matrix rendering
+- Mermaid flowchart rendering
+- Mermaid xychart rendering

--- a/src/DiagramForge/Parsers/Conceptual/ConceptualDslParser.cs
+++ b/src/DiagramForge/Parsers/Conceptual/ConceptualDslParser.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DiagramForge.Abstractions;
 using DiagramForge.Models;
 
@@ -23,10 +24,8 @@ public sealed class ConceptualDslParser : IDiagramParser
 {
     public string SyntaxId => "conceptual";
 
-    private static readonly HashSet<string> KnownTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "matrix", "pyramid",
-    };
+    private static readonly FrozenSet<string> KnownTypes = new[] { "matrix", "pyramid" }
+        .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public bool CanParse(string diagramText)
@@ -34,11 +33,13 @@ public sealed class ConceptualDslParser : IDiagramParser
         if (string.IsNullOrWhiteSpace(diagramText))
             return false;
 
-        var firstLine = diagramText.TrimStart().Split('\n')[0].Trim();
+        if (!TryReadFirstNonEmptyLine(diagramText.AsSpan(), out var firstLine))
+            return false;
+
         if (!firstLine.StartsWith("diagram:", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var typeValue = firstLine["diagram:".Length..].Trim().ToLowerInvariant();
+        var typeValue = firstLine["diagram:".Length..].Trim().ToString();
         return KnownTypes.Contains(typeValue);
     }
 
@@ -48,10 +49,7 @@ public sealed class ConceptualDslParser : IDiagramParser
         if (string.IsNullOrWhiteSpace(diagramText))
             throw new DiagramParseException("Diagram text cannot be null or empty.");
 
-        var lines = diagramText
-            .Split('\n')
-            .Select(l => l.TrimEnd())
-            .ToArray();
+        var lines = ReadLines(diagramText);
 
         if (lines.Length == 0)
             throw new DiagramParseException("Diagram text is empty.");
@@ -150,6 +148,66 @@ public sealed class ConceptualDslParser : IDiagramParser
 
     private static List<string> ReadListItems(string[] lines, int startIndex)
         => [.. EnumerateListItems(lines, startIndex)];
+
+    private static string[] ReadLines(string text)
+    {
+        var lines = new List<string>();
+
+        var span = text.AsSpan();
+        int start = 0;
+        while (start <= span.Length)
+        {
+            int length = 0;
+            while (start + length < span.Length && span[start + length] != '\n')
+                length++;
+
+            lines.Add(TrimLineEnd(span.Slice(start, length)).ToString());
+
+            start += length + 1;
+            if (start > span.Length)
+                break;
+        }
+
+        return [.. lines];
+    }
+
+    private static bool TryReadFirstNonEmptyLine(ReadOnlySpan<char> text, out ReadOnlySpan<char> line)
+    {
+        int start = 0;
+        while (start <= text.Length)
+        {
+            int length = 0;
+            while (start + length < text.Length && text[start + length] != '\n')
+                length++;
+
+            var candidate = text.Slice(start, length);
+            if (!candidate.IsEmpty && candidate[^1] == '\r')
+                candidate = candidate[..^1];
+
+            var trimmed = candidate.Trim();
+            if (!trimmed.IsEmpty)
+            {
+                line = trimmed;
+                return true;
+            }
+
+            start += length + 1;
+            if (start > text.Length)
+                break;
+        }
+
+        line = default;
+        return false;
+    }
+
+    private static ReadOnlySpan<char> TrimLineEnd(ReadOnlySpan<char> line)
+    {
+        int end = line.Length;
+        while (end > 0 && char.IsWhiteSpace(line[end - 1]) && line[end - 1] != '\n' && line[end - 1] != '\r')
+            end--;
+
+        return line[..end];
+    }
 
     private static IEnumerable<string> EnumerateListItems(string[] lines, int startIndex)
     {

--- a/src/DiagramForge/Parsers/Mermaid/MermaidDocument.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidDocument.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DiagramForge.Abstractions;
 
 namespace DiagramForge.Parsers.Mermaid;
@@ -30,14 +31,33 @@ internal sealed class MermaidDocument
         var lines = new List<string>();
         var rawLines = new List<string>();
 
-        foreach (var line in diagramText.Split('\n'))
+        var text = diagramText.AsSpan();
+        int start = 0;
+        while (start <= text.Length)
         {
-            var trimmedStart = line.TrimStart();
-            if (string.IsNullOrWhiteSpace(line) || trimmedStart.StartsWith("%%", StringComparison.Ordinal))
-                continue;
+            int length = 0;
+            while (start + length < text.Length && text[start + length] != '\n')
+                length++;
 
-            rawLines.Add(line.TrimEnd());
-            lines.Add(line.Trim());
+            var line = text.Slice(start, length);
+            if (!line.IsEmpty && line[^1] == '\r')
+                line = line[..^1];
+
+            var trimmedStart = line.TrimStart();
+            if (trimmedStart.IsEmpty || trimmedStart.StartsWith("%%", StringComparison.Ordinal))
+            {
+                start += length + 1;
+                if (start > text.Length)
+                    break;
+                continue;
+            }
+
+            rawLines.Add(TrimLineEnd(line).ToString());
+            lines.Add(trimmedStart.TrimEnd().ToString());
+
+            start += length + 1;
+            if (start > text.Length)
+                break;
         }
 
         if (lines.Count == 0)
@@ -60,7 +80,7 @@ internal sealed class MermaidDocument
     // Known Mermaid diagram-type keywords (lowercased) that are recognized but not yet
     // supported by any registered IMermaidDiagramParser. Detecting them as Unknown lets
     // MermaidParser emit a specific "unsupported type" error instead of a generic one.
-    private static readonly HashSet<string> KnownUnsupportedMermaidKeywords = new(StringComparer.Ordinal)
+    private static readonly FrozenSet<string> KnownUnsupportedMermaidKeywords = new[]
     {
         "classdiagram",
         "erdiagram",
@@ -76,7 +96,7 @@ internal sealed class MermaidDocument
         "zenuml",
         "radar-beta",
         "treemap-beta",
-    };
+    }.ToFrozenSet(StringComparer.Ordinal);
 
     public static MermaidDocument Parse(string diagramText)
     {
@@ -86,10 +106,30 @@ internal sealed class MermaidDocument
         if (string.IsNullOrWhiteSpace(diagramText))
             throw new DiagramParseException("Diagram text cannot be null or whitespace.");
 
-        var firstContentLine = diagramText
-            .Split('\n')
-            .Select(line => line.Trim())
-            .FirstOrDefault(line => !string.IsNullOrEmpty(line) && !line.StartsWith("%%", StringComparison.Ordinal));
+        string? firstContentLine = null;
+        var text = diagramText.AsSpan();
+        int start = 0;
+        while (start <= text.Length)
+        {
+            int length = 0;
+            while (start + length < text.Length && text[start + length] != '\n')
+                length++;
+
+            var line = text.Slice(start, length);
+            if (!line.IsEmpty && line[^1] == '\r')
+                line = line[..^1];
+
+            var trimmed = line.Trim();
+            if (!trimmed.IsEmpty && !trimmed.StartsWith("%%", StringComparison.Ordinal))
+            {
+                firstContentLine = trimmed.ToString();
+                break;
+            }
+
+            start += length + 1;
+            if (start > text.Length)
+                break;
+        }
 
         if (firstContentLine is null)
             throw new DiagramParseException("Diagram text cannot be empty or contain only comments.");
@@ -167,5 +207,14 @@ internal sealed class MermaidDocument
 
         kind = default;
         return false;
+    }
+
+    private static ReadOnlySpan<char> TrimLineEnd(ReadOnlySpan<char> line)
+    {
+        int end = line.Length;
+        while (end > 0 && char.IsWhiteSpace(line[end - 1]) && line[end - 1] != '\n' && line[end - 1] != '\r')
+            end--;
+
+        return line[..end];
     }
 }

--- a/src/DiagramForge/Parsers/Mermaid/MermaidXyChartParser.cs
+++ b/src/DiagramForge/Parsers/Mermaid/MermaidXyChartParser.cs
@@ -18,22 +18,16 @@ namespace DiagramForge.Parsers.Mermaid;
 ///   <item><c>line [v1, v2, …]</c> data series (multiple allowed)</item>
 /// </list>
 /// </remarks>
-internal sealed class MermaidXyChartParser : IMermaidDiagramParser
+internal sealed partial class MermaidXyChartParser : IMermaidDiagramParser
 {
-    // Matches a bracketed list of values: [a, b, c] or [100, 200, 300]
-    private static readonly Regex BracketListRegex = new(
-        @"\[([^\]]*)\]",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"\[([^\]]*)\]", RegexOptions.CultureInvariant)]
+    private static partial Regex BracketListRegex();
 
-    // Matches a numeric range: 4000 --> 11000
-    private static readonly Regex NumericRangeRegex = new(
-        @"([\d.]+)\s*-->\s*([\d.]+)",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"([\d.]+)\s*-->\s*([\d.]+)", RegexOptions.CultureInvariant)]
+    private static partial Regex NumericRangeRegex();
 
-    // Matches a quoted string: "Sales Revenue"
-    private static readonly Regex QuotedStringRegex = new(
-        @"""([^""]*)""",
-        RegexOptions.Compiled);
+    [GeneratedRegex(@"""([^""]*)""", RegexOptions.CultureInvariant)]
+    private static partial Regex QuotedStringRegex();
 
     public bool CanParse(MermaidDiagramKind kind) => kind == MermaidDiagramKind.XyChart;
 
@@ -59,7 +53,7 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
             if (line.StartsWith("title ", StringComparison.OrdinalIgnoreCase))
             {
                 var titleText = line["title ".Length..].Trim();
-                var quoted = QuotedStringRegex.Match(titleText);
+                var quoted = QuotedStringRegex().Match(titleText);
                 builder.WithTitle(quoted.Success ? quoted.Groups[1].Value : titleText);
                 continue;
             }
@@ -68,14 +62,14 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
             if (line.StartsWith("x-axis", StringComparison.OrdinalIgnoreCase))
             {
                 var rest = line["x-axis".Length..].Trim();
-                var bracketMatch = BracketListRegex.Match(rest);
+                var bracketMatch = BracketListRegex().Match(rest);
                 if (bracketMatch.Success)
                 {
                     xCategories = ParseStringList(bracketMatch.Groups[1].Value);
                 }
                 else
                 {
-                    var rangeMatch = NumericRangeRegex.Match(rest);
+                    var rangeMatch = NumericRangeRegex().Match(rest);
                     if (rangeMatch.Success)
                     {
                         xMin = ParseDouble(rangeMatch.Groups[1].Value);
@@ -89,13 +83,13 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
             if (line.StartsWith("y-axis", StringComparison.OrdinalIgnoreCase))
             {
                 var rest = line["y-axis".Length..].Trim();
-                var quotedMatch = QuotedStringRegex.Match(rest);
+                var quotedMatch = QuotedStringRegex().Match(rest);
                 if (quotedMatch.Success)
                 {
                     yLabel = quotedMatch.Groups[1].Value;
                     rest = rest[(quotedMatch.Index + quotedMatch.Length)..].Trim();
                 }
-                var rangeMatch = NumericRangeRegex.Match(rest);
+                var rangeMatch = NumericRangeRegex().Match(rest);
                 if (rangeMatch.Success)
                 {
                     yMin = ParseDouble(rangeMatch.Groups[1].Value);
@@ -107,7 +101,7 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
             // bar [5000, 6000, 7500]
             if (line.StartsWith("bar", StringComparison.OrdinalIgnoreCase))
             {
-                var bracketMatch = BracketListRegex.Match(line);
+                var bracketMatch = BracketListRegex().Match(line);
                 if (bracketMatch.Success)
                     barSeries.Add(ParseDoubleList(bracketMatch.Groups[1].Value));
                 continue;
@@ -116,7 +110,7 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
             // line [5000, 6000, 7000]
             if (line.StartsWith("line", StringComparison.OrdinalIgnoreCase))
             {
-                var bracketMatch = BracketListRegex.Match(line);
+                var bracketMatch = BracketListRegex().Match(line);
                 if (bracketMatch.Success)
                     lineSeries.Add(ParseDoubleList(bracketMatch.Groups[1].Value));
                 continue;
@@ -137,14 +131,32 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
         xCategories ??= GenerateNumericLabels(categoryCount, xMin, xMax);
 
         // Auto-compute Y range from data if not specified.
-        var allValues = barSeries.SelectMany(s => s)
-            .Concat(lineSeries.SelectMany(s => s))
-            .ToList();
+        bool hasValues = false;
+        double maxValue = 0;
+        foreach (var series in barSeries)
+        {
+            for (int i = 0; i < series.Length; i++)
+            {
+                if (!hasValues || series[i] > maxValue)
+                    maxValue = series[i];
+                hasValues = true;
+            }
+        }
 
-        if (allValues.Count > 0)
+        foreach (var series in lineSeries)
+        {
+            for (int i = 0; i < series.Length; i++)
+            {
+                if (!hasValues || series[i] > maxValue)
+                    maxValue = series[i];
+                hasValues = true;
+            }
+        }
+
+        if (hasValues)
         {
             yMin ??= 0;
-            yMax ??= allValues.Max() * 1.1; // 10% headroom
+            yMax ??= maxValue * 1.1; // 10% headroom
         }
         else
         {
@@ -206,22 +218,53 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
 
     private static string[] ParseStringList(string csv)
     {
-        return csv.Split(',')
-            .Select(s => s.Trim().Trim('"'))
-            .Where(s => !string.IsNullOrEmpty(s))
-            .ToArray();
+        var values = new List<string>();
+        var text = csv.AsSpan();
+        int start = 0;
+        while (start <= text.Length)
+        {
+            int length = 0;
+            while (start + length < text.Length && text[start + length] != ',')
+                length++;
+
+            var part = text.Slice(start, length);
+            var value = part.Trim().Trim('"');
+            if (!value.IsEmpty)
+                values.Add(value.ToString());
+
+            start += length + 1;
+            if (start > text.Length)
+                break;
+        }
+
+        return [.. values];
     }
 
     private static double[] ParseDoubleList(string csv)
     {
-        return csv.Split(',')
-            .Select(s => s.Trim())
-            .Where(s => !string.IsNullOrEmpty(s))
-            .Select(ParseDouble)
-            .ToArray();
+        var values = new List<double>();
+        var text = csv.AsSpan();
+        int start = 0;
+        while (start <= text.Length)
+        {
+            int length = 0;
+            while (start + length < text.Length && text[start + length] != ',')
+                length++;
+
+            var part = text.Slice(start, length);
+            var value = part.Trim();
+            if (!value.IsEmpty)
+                values.Add(ParseDouble(value));
+
+            start += length + 1;
+            if (start > text.Length)
+                break;
+        }
+
+        return [.. values];
     }
 
-    private static double ParseDouble(string s)
+    private static double ParseDouble(ReadOnlySpan<char> s)
     {
         return double.Parse(s.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture);
     }
@@ -238,4 +281,5 @@ internal sealed class MermaidXyChartParser : IMermaidDiagramParser
         }
         return Enumerable.Range(1, count).Select(i => i.ToString(CultureInfo.InvariantCulture)).ToArray();
     }
+
 }

--- a/tests/DiagramForge.Tests/Parsers/ConceptualDslParserTests.cs
+++ b/tests/DiagramForge.Tests/Parsers/ConceptualDslParserTests.cs
@@ -77,6 +77,18 @@ public class ConceptualDslParserTests
         Assert.Contains("exactly 2 rows and 2 columns", ex.Message);
     }
 
+    [Fact]
+    public void Parse_Matrix_WithCrLfLineEndings_ProducesFourQuadrantNodes()
+    {
+        const string text = "diagram: matrix\r\nrows:\r\n  - Row A\r\n  - Row B\r\ncolumns:\r\n  - Col 1\r\n  - Col 2\r\n";
+
+        var diagram = _parser.Parse(text);
+
+        Assert.Equal(4, diagram.Nodes.Count);
+        Assert.Equal("Col 1\nRow A", diagram.Nodes["cell_0_0"].Label.Text);
+        Assert.Equal("Col 2\nRow B", diagram.Nodes["cell_1_1"].Label.Text);
+    }
+
     // ── Pyramid ───────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/DiagramForge.Tests/Parsers/MermaidParserTests.cs
+++ b/tests/DiagramForge.Tests/Parsers/MermaidParserTests.cs
@@ -437,6 +437,42 @@ public class MermaidParserTests
     }
 
     [Fact]
+    public void Parse_LeadingCommentsAndBlankLines_WithCrLf_DispatchesToFlowchartParser()
+    {
+        const string text = "\r\n%% comment before header\r\n\r\n%% another comment\r\nflowchart LR\r\n  A --> B\r\n";
+
+        var diagram = _parser.Parse(text);
+
+        Assert.Equal("flowchart", diagram.DiagramType);
+        Assert.Equal("mermaid", diagram.SourceSyntax);
+        Assert.Single(diagram.Edges);
+    }
+
+    [Fact]
+    public void Parse_XyChart_WithFlexibleWhitespace_ParsesCategoriesAndSeries()
+    {
+        const string text = """
+            xychart-beta
+              title "Quarterly Revenue"
+              x-axis [ Q1 ,  Q2, Q3 ]
+              y-axis "Revenue"   0   -->   10
+              bar [ 1 , 2 , 3 ]
+              line [ 3, 2 , 1 ]
+            """;
+
+        var diagram = _parser.Parse(text);
+
+        Assert.Equal("xychart", diagram.DiagramType);
+        Assert.Equal("Quarterly Revenue", diagram.Title);
+        Assert.Equal(6, diagram.Nodes.Count);
+
+        var categories = Assert.IsType<string[]>(diagram.Metadata["xychart:categories"]);
+        Assert.Equal(["Q1", "Q2", "Q3"], categories);
+        Assert.Equal(0d, Convert.ToDouble(diagram.Metadata["xychart:yMin"], System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(10d, Convert.ToDouble(diagram.Metadata["xychart:yMax"], System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
     public void Parse_UnsupportedMermaidDiagramType_ThrowsDiagramParseException()
     {
         var ex = Assert.Throws<DiagramParseException>(() =>


### PR DESCRIPTION
## Summary
- modernize Mermaid parser regex usage and reduce allocation-heavy parser hot paths
- add focused regression tests for CRLF handling, comment normalization, and xychart whitespace parsing
- add a BenchmarkDotNet project and performance notes for measuring render throughput and allocations

## Validation
- `dotnet test tests/DiagramForge.Tests/DiagramForge.Tests.csproj --filter "FullyQualifiedName~ConceptualDslParserTests|FullyQualifiedName~MermaidParserTests"`
