### PR TITLE
feat: wrap long node labels

### DIFF
--- a/src/DiagramForge/Layout/DefaultLayoutEngine.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.cs
@@ -27,6 +27,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     private const double BlockHGapWide = 50;
     private const double BlockVGapWide = 40;
     private const double PyramidLevelGap = 6;
+    private const double DefaultLabelLineHeight = 1.15;
 
     /// <summary>
     /// Average glyph advance as a fraction of font size (em-units) for typical
@@ -52,6 +53,8 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         double hGap = hints.HorizontalSpacing;
         double vGap = hints.VerticalSpacing;
         double pad = theme.DiagramPadding;
+
+        PrepareNodeLabels(diagram, theme);
 
         if (string.Equals(diagram.DiagramType, "block", StringComparison.OrdinalIgnoreCase))
         {
@@ -110,12 +113,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         // produce skinny boxes.
 
         foreach (var node in diagram.Nodes.Values)
-        {
-            double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textW = EstimateTextWidth(node.Label.Text, fontSize);
-            node.Width = Math.Max(minW, textW + 2 * theme.NodePadding);
-            node.Height = nodeH;
-        }
+            SizeStandardNode(node, theme, minW, nodeH);
 
         // ── Positioning pass ──────────────────────────────────────────────────
         // Assign nodes to layers via BFS, then place them. Because widths are now
@@ -147,11 +145,12 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
                     continue;
 
                 double maxWidthInColumn = layer.Max(n => n.Width);
-                for (int i = 0; i < layer.Count; i++)
+                double runY = pad;
+                foreach (var node in layer)
                 {
-                    var node = layer[i];
                     node.X = columnX;
-                    node.Y = pad + i * (nodeH + vGap);
+                    node.Y = runY;
+                    runY += node.Height + vGap;
                 }
                 columnX += maxWidthInColumn + hGap;
             }
@@ -165,13 +164,14 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
                     continue; // see comment above
 
                 double runX = pad;
+                double rowHeight = layer.Max(node => node.Height);
                 foreach (var node in layer)
                 {
                     node.X = runX;
-                    node.Y = rowY;
+                    node.Y = rowY + (rowHeight - node.Height) / 2;
                     runX += node.Width + hGap;
                 }
-                rowY += nodeH + vGap;
+                rowY += rowHeight + vGap;
             }
         }
 
@@ -297,8 +297,6 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         // ── Sizing pass ───────────────────────────────────────────────────────
         foreach (var node in diagram.Nodes.Values)
         {
-            double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textW = EstimateTextWidth(node.Label.Text, fontSize);
             // Junctions (Shape.Circle, no label) get a small fixed size.
             if (node.Shape == Models.Shape.Circle && string.IsNullOrEmpty(node.Label.Text))
             {
@@ -307,8 +305,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             }
             else
             {
-                node.Width = Math.Max(minW, textW + 2 * theme.NodePadding);
-                node.Height = nodeH;
+                SizeStandardNode(node, theme, minW, nodeH);
             }
         }
 
@@ -536,7 +533,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         double widestLabel = orderedNodes.Max(node =>
         {
             double fontSize = node.Label.FontSize ?? theme.FontSize;
-            return EstimateTextWidth(node.Label.Text, fontSize) + 2 * theme.NodePadding;
+            return EstimateTextWidth(node.Label, fontSize) + 2 * theme.NodePadding;
         });
 
         int levelCount = orderedNodes.Count;
@@ -572,12 +569,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     {
         // Size each participant node from its label.
         foreach (var node in diagram.Nodes.Values)
-        {
-            double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textW = EstimateTextWidth(node.Label.Text, fontSize);
-            node.Width = Math.Max(minW, textW + 2 * theme.NodePadding);
-            node.Height = nodeH;
-        }
+            SizeStandardNode(node, theme, minW, nodeH);
 
         // Order participants by their declared index (stored during parsing).
         // ThenBy ensures deterministic output when the index is missing or two
@@ -591,16 +583,17 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
 
         // Place participants in a single row across the top of the diagram.
         double runX = pad;
+        double participantStripHeight = ordered.Max(node => node.Height);
         foreach (var node in ordered)
         {
             node.X = runX;
-            node.Y = pad;
+            node.Y = pad + (participantStripHeight - node.Height);
             runX += node.Width + hGap;
         }
 
         // Assign each message edge its own Y row below the participant strip.
         // Each row is vGap tall, giving space for the arrow line and any label above it.
-        double firstMessageY = pad + nodeH + vGap / 2;
+        double firstMessageY = pad + participantStripHeight + vGap / 2;
         double messageRowHeight = vGap;
 
         foreach (var edge in diagram.Edges)
@@ -629,12 +622,8 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     {
         foreach (var node in diagram.Nodes.Values)
         {
-            double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textW = EstimateTextWidth(node.Label.Text, fontSize);
             bool isArrow = node.Shape is Shape.ArrowRight or Shape.ArrowLeft or Shape.ArrowUp or Shape.ArrowDown;
-
-            node.Width = Math.Max(isArrow ? minW * 0.75 : minW, textW + 2 * theme.NodePadding);
-            node.Height = isArrow ? nodeH + 8 : nodeH;
+            SizeStandardNode(node, theme, isArrow ? minW * 0.75 : minW, isArrow ? nodeH + 8 : nodeH);
         }
 
         var placedNodes = diagram.Nodes.Values
@@ -697,12 +686,7 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     {
         // Size all nodes from their labels.
         foreach (var node in diagram.Nodes.Values)
-        {
-            double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textW = EstimateTextWidth(node.Label.Text, fontSize);
-            node.Width = Math.Max(minW, textW + 2 * theme.NodePadding);
-            node.Height = nodeH;
-        }
+            SizeStandardNode(node, theme, minW, nodeH);
 
         // Collect period nodes in declaration order.
         var periodNodes = diagram.Nodes.Values
@@ -732,19 +716,23 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
 
         // Place period nodes in a single horizontal row.
         double periodY = pad + titleOffset;
+        double periodRowHeight = periodNodes.Max(node => node.Height);
         for (int i = 0; i < periodNodes.Count; i++)
         {
             var pn = periodNodes[i];
             pn.X = pad + i * (colWidth + hGap);
-            pn.Y = periodY;
+            pn.Y = periodY + (periodRowHeight - pn.Height) / 2;
             pn.Width = colWidth;
         }
 
         // Place event nodes in columns below their owning period.
+        var nextEventYByPeriod = periodNodes.ToDictionary(
+            node => GetMetadataInt(node.Metadata, "timeline:periodIndex"),
+            _ => periodY + periodRowHeight + vGap);
+
         foreach (var eventNode in eventNodes)
         {
             int pIdx = GetMetadataInt(eventNode.Metadata, "timeline:periodIndex");
-            int eIdx = GetMetadataInt(eventNode.Metadata, "timeline:eventIndex");
 
             var periodNode = periodNodes.Find(n =>
                 GetMetadataInt(n.Metadata, "timeline:periodIndex") == pIdx);
@@ -753,7 +741,8 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
                 continue;
 
             eventNode.X = periodNode.X;
-            eventNode.Y = periodY + nodeH + vGap + eIdx * (nodeH + vGap);
+            eventNode.Y = nextEventYByPeriod[pIdx];
+            nextEventYByPeriod[pIdx] += eventNode.Height + vGap;
             eventNode.Width = colWidth;
         }
     }
@@ -814,11 +803,11 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
         double diameter = setNodes.Max(node =>
         {
             double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double labelWidth = EstimateTextWidth(node.Label.Text, fontSize);
+            double labelWidth = EstimateTextWidth(node.Label, fontSize);
             var nestedTextNodes = GetSetTextNodes(textNodes, node.Id).ToList();
             double nestedTextWidth = nestedTextNodes.Count == 0
                 ? 0
-                : nestedTextNodes.Max(textNode => EstimateTextWidth(textNode.Label.Text, textNode.Label.FontSize ?? theme.FontSize));
+                : nestedTextNodes.Max(textNode => EstimateTextWidth(textNode.Label, textNode.Label.FontSize ?? theme.FontSize));
             double nestedHeightAllowance = nestedTextNodes.Count == 0
                 ? 0
                 : nestedTextNodes.Count * fontSize * 1.15 + fontSize * 1.8;
@@ -981,8 +970,8 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
 
         double titleOffset = !string.IsNullOrWhiteSpace(diagram.Title) ? theme.TitleFontSize + 8 : 0;
         double baseFontSize = cells.Max(node => node.Label.FontSize ?? theme.FontSize);
-        int maxLineCount = cells.Max(node => GetTextLineCount(node.Label.Text));
-        double maxTextWidth = cells.Max(node => EstimateTextWidth(node.Label.Text, node.Label.FontSize ?? theme.FontSize));
+        int maxLineCount = cells.Max(node => GetTextLineCount(node.Label));
+        double maxTextWidth = cells.Max(node => EstimateTextWidth(node.Label, node.Label.FontSize ?? theme.FontSize));
 
         double cellWidth = Math.Max(minW + 24, maxTextWidth + theme.NodePadding * 2.5);
         double textBlockHeight = Math.Max(1, maxLineCount) * baseFontSize * 1.15;
@@ -1153,6 +1142,126 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
     /// query for <c>getBBox()</c>; this gets us within ±10% for Latin text, which
     /// is sufficient for layout (padding absorbs the slop).
     /// </summary>
+    private static void PrepareNodeLabels(Diagram diagram, Theme theme)
+    {
+        foreach (var node in diagram.Nodes.Values)
+            PrepareLabelLines(node.Label, theme, diagram.LayoutHints);
+    }
+
+    private static void PrepareLabelLines(Label label, Theme theme, LayoutHints hints)
+    {
+        double fontSize = label.FontSize ?? theme.FontSize;
+        double maxTextWidth = hints.MaxNodeWidth.HasValue
+            ? Math.Max(1, hints.MaxNodeWidth.Value - 2 * theme.NodePadding)
+            : double.PositiveInfinity;
+
+        label.Lines = WrapLabelText(label.Text, fontSize, maxTextWidth);
+    }
+
+    private static string[] WrapLabelText(string? text, double fontSize, double maxTextWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+            return [];
+
+        var lines = new List<string>();
+        foreach (var paragraph in text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n'))
+        {
+            if (paragraph.Length == 0)
+            {
+                lines.Add(string.Empty);
+                continue;
+            }
+
+            if (double.IsPositiveInfinity(maxTextWidth) || EstimateTextWidth(paragraph, fontSize) <= maxTextWidth)
+            {
+                lines.Add(paragraph);
+                continue;
+            }
+
+            WrapParagraph(paragraph, fontSize, maxTextWidth, lines);
+        }
+
+        return [.. lines];
+    }
+
+    private static void WrapParagraph(string paragraph, double fontSize, double maxTextWidth, List<string> lines)
+    {
+        string currentLine = string.Empty;
+
+        foreach (var word in paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string candidate = string.IsNullOrEmpty(currentLine) ? word : $"{currentLine} {word}";
+            if (EstimateTextWidth(candidate, fontSize) <= maxTextWidth)
+            {
+                currentLine = candidate;
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(currentLine))
+            {
+                lines.Add(currentLine);
+                currentLine = string.Empty;
+            }
+
+            if (EstimateTextWidth(word, fontSize) <= maxTextWidth)
+            {
+                currentLine = word;
+                continue;
+            }
+
+            foreach (var chunk in BreakWord(word, fontSize, maxTextWidth))
+            {
+                if (string.IsNullOrEmpty(currentLine))
+                {
+                    currentLine = chunk;
+                }
+                else
+                {
+                    lines.Add(currentLine);
+                    currentLine = chunk;
+                }
+            }
+        }
+
+        if (!string.IsNullOrEmpty(currentLine))
+            lines.Add(currentLine);
+    }
+
+    private static IEnumerable<string> BreakWord(string word, double fontSize, double maxTextWidth)
+    {
+        if (string.IsNullOrEmpty(word))
+            yield break;
+
+        var chunk = new System.Text.StringBuilder();
+        foreach (var ch in word)
+        {
+            string candidate = chunk.ToString() + ch;
+            if (chunk.Length > 0 && EstimateTextWidth(candidate, fontSize) > maxTextWidth)
+            {
+                yield return chunk.ToString();
+                chunk.Clear();
+            }
+
+            chunk.Append(ch);
+        }
+
+        if (chunk.Length > 0)
+            yield return chunk.ToString();
+    }
+
+    private static void SizeStandardNode(Node node, Theme theme, double minWidth, double minHeight)
+    {
+        double fontSize = node.Label.FontSize ?? theme.FontSize;
+        double textWidth = EstimateTextWidth(node.Label, fontSize);
+        double textBlockHeight = GetTextBlockHeight(node.Label, fontSize);
+
+        node.Width = Math.Max(minWidth, textWidth + 2 * theme.NodePadding);
+        node.Height = Math.Max(minHeight, textBlockHeight + 2 * theme.NodePadding);
+    }
+
+    private static double EstimateTextWidth(Label label, double fontSize) =>
+        EstimateTextWidth(string.Join('\n', GetLabelLines(label)), fontSize);
+
     private static double EstimateTextWidth(string? text, double fontSize)
     {
         if (string.IsNullOrEmpty(text))
@@ -1164,13 +1273,21 @@ public sealed class DefaultLayoutEngine : ILayoutEngine
             .Max(line => line.Length) * fontSize * AvgGlyphAdvanceEm;
     }
 
-    private static int GetTextLineCount(string? text)
+    private static int GetTextLineCount(Label label) => GetLabelLines(label).Length;
+
+    private static double GetTextBlockHeight(Label label, double fontSize)
     {
-        if (string.IsNullOrEmpty(text))
+        int lineCount = GetTextLineCount(label);
+        if (lineCount == 0)
             return 0;
 
-        return text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n').Length;
+        return fontSize + (lineCount - 1) * fontSize * DefaultLabelLineHeight;
     }
+
+    private static string[] GetLabelLines(Label label) =>
+        label.Lines is { Length: > 0 }
+            ? label.Lines
+            : label.Text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n');
 
     /// <summary>
     /// Shifts all nodes and groups so that every group's top-left corner is at least

--- a/src/DiagramForge/Models/Label.cs
+++ b/src/DiagramForge/Models/Label.cs
@@ -16,6 +16,9 @@ public class Label
     /// <summary>Optional tooltip / long-form description.</summary>
     public string? Tooltip { get; set; }
 
+    /// <summary>Computed line breaks used for wrapped SVG rendering.</summary>
+    public string[]? Lines { get; set; }
+
     /// <summary>Override font size (null = inherit from theme).</summary>
     public double? FontSize { get; set; }
 

--- a/src/DiagramForge/Models/LayoutHints.cs
+++ b/src/DiagramForge/Models/LayoutHints.cs
@@ -20,6 +20,9 @@ public class LayoutHints
     /// <summary>Minimum width of a node (in SVG user units).</summary>
     public double MinNodeWidth { get; set; } = 120;
 
+    /// <summary>Maximum width of a node before text wrapping kicks in.</summary>
+    public double? MaxNodeWidth { get; set; } = 240;
+
     /// <summary>Minimum height of a node (in SVG user units).</summary>
     public double MinNodeHeight { get; set; } = 40;
 

--- a/src/DiagramForge/Rendering/SvgNodeWriter.cs
+++ b/src/DiagramForge/Rendering/SvgNodeWriter.cs
@@ -5,6 +5,8 @@ namespace DiagramForge.Rendering;
 
 internal static class SvgNodeWriter
 {
+    private const double DefaultLabelLineHeight = 1.15;
+
     internal static void AppendNode(StringBuilder sb, Node node, Theme theme, int nodeIndex = 0)
     {
         string? xyChartKind = node.Metadata.TryGetValue("xychart:kind", out var xyKindObj) ? xyKindObj as string : null;
@@ -111,10 +113,13 @@ internal static class SvgNodeWriter
         else if (SvgRenderSupport.HasTextOnlyBackdrop(node, fillOpacity))
         {
             double fontSize = node.Label.FontSize ?? theme.FontSize;
-            double textWidth = SvgRenderSupport.EstimateTextWidth(node.Label.Text, fontSize);
+            var lines = GetRenderedLabelLines(node.Label);
+            double textWidth = lines.Length == 0 ? 0 : lines.Max(line => SvgRenderSupport.EstimateTextWidth(line, fontSize));
             double horizontalPadding = theme.NodePadding * 0.4;
-            double top = -fontSize * 0.80;
-            double height = fontSize * 1.25;
+            double lineHeight = fontSize * DefaultLabelLineHeight;
+            double textBlockHeight = lines.Length == 0 ? fontSize : fontSize + (lines.Length - 1) * lineHeight;
+            double top = -textBlockHeight * 0.65;
+            double height = textBlockHeight + fontSize * 0.25;
             double width = textWidth + horizontalPadding * 2;
             sb.AppendLine($"""    <rect x="{SvgRenderSupport.F(-width / 2)}" y="{SvgRenderSupport.F(top)}" width="{SvgRenderSupport.F(width)}" height="{SvgRenderSupport.F(height)}" rx="{SvgRenderSupport.F(fontSize * 0.35)}" ry="{SvgRenderSupport.F(fontSize * 0.35)}" fill="{fill}" stroke="{stroke}" stroke-width="{SvgRenderSupport.F(theme.StrokeWidth)}"{fillOpacityAttribute}/>""");
         }
@@ -127,7 +132,7 @@ internal static class SvgNodeWriter
             double textX = SvgRenderSupport.GetMetadataDouble(node, "label:centerX") ?? (textOnly ? 0 : (node.Width / 2));
             double textBaselineY = SvgRenderSupport.GetMetadataDouble(node, "label:centerY") ?? (textOnly ? 0 : (node.Height / 2));
 
-            AppendNodeLabel(sb, node.Label.Text, theme, textX, textBaselineY, fontSize, textColor);
+            AppendNodeLabel(sb, node.Label, theme, textX, textBaselineY, fontSize, textColor);
         }
 
         sb.AppendLine("  </g>");
@@ -135,15 +140,15 @@ internal static class SvgNodeWriter
 
     private static void AppendNodeLabel(
         StringBuilder sb,
-        string labelText,
+        Label label,
         Theme theme,
         double centerX,
         double centerY,
         double fontSize,
         string textColor)
     {
-        var lines = labelText.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n');
-        double lineHeight = fontSize * 1.15;
+        var lines = GetRenderedLabelLines(label);
+        double lineHeight = fontSize * DefaultLabelLineHeight;
         double firstBaselineY = centerY + fontSize * 0.35 - ((lines.Length - 1) * lineHeight / 2);
 
         if (lines.Length == 1)
@@ -160,6 +165,11 @@ internal static class SvgNodeWriter
 
         sb.AppendLine("    </text>");
     }
+
+    private static string[] GetRenderedLabelLines(Label label) =>
+        label.Lines is { Length: > 0 }
+            ? label.Lines
+            : label.Text.Replace("\r", string.Empty, StringComparison.Ordinal).Split('\n');
 
     private static void AppendArrowPolygon(StringBuilder sb, double width, double height, string fill, string stroke, Theme theme, string direction, string shadowAttribute)
     {

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-flowchart-wrapped-label.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-flowchart-wrapped-label.expected.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="462.60" height="144.80" viewBox="0 0 462.60 144.80">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#516074"/>
+    </marker>
+  </defs>
+  <rect width="462.60" height="144.80" fill="#FCFCFD" rx="8.00" ry="8.00"/>
+  <path d="M 258.60,72.40 C 285.15,72.40 294.60,55.36 318.60,44.00" fill="none" stroke="#516074" stroke-width="1.50"  marker-end="url(#arrowhead)" />
+  <g transform="translate(24.00,24.00)">
+    <defs>
+      <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#EBF3FF"/>
+        <stop offset="58%" stop-color="#EAF2FF"/>
+        <stop offset="100%" stop-color="#DBE3EF"/>
+      </linearGradient>
+      <linearGradient id="node-0-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#B3B9C2"/>
+        <stop offset="100%" stop-color="#AAB2C2"/>
+      </linearGradient>
+    </defs>
+    <rect width="234.60" height="96.80" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.50"/>
+    <text x="117.30" y="23.05" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#0F172A">
+      <tspan x="117.30" y="23.05">This is a deliberately long</tspan>
+      <tspan x="117.30" dy="14.95">label that should wrap</tspan>
+      <tspan x="117.30" dy="14.95">instead of producing an</tspan>
+      <tspan x="117.30" dy="14.95">absurdly wide node box in</tspan>
+      <tspan x="117.30" dy="14.95">the rendered diagram</tspan>
+    </text>
+  </g>
+  <g transform="translate(318.60,24.00)">
+    <defs>
+      <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#EAF7F1"/>
+        <stop offset="58%" stop-color="#E8F7F0"/>
+        <stop offset="100%" stop-color="#DAE8E1"/>
+      </linearGradient>
+      <linearGradient id="node-1-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#B2BDB8"/>
+        <stop offset="100%" stop-color="#A9B6B8"/>
+      </linearGradient>
+    </defs>
+    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.50"/>
+    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#0F172A">Ship</text>
+  </g>
+</svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-flowchart-wrapped-label.input
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-flowchart-wrapped-label.input
@@ -1,0 +1,5 @@
+---
+theme: default
+---
+flowchart LR
+  A[This is a deliberately long label that should wrap instead of producing an absurdly wide node box in the rendered diagram] --> B[Ship]

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap-presentation.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap-presentation.expected.svg
@@ -1,17 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="724.00" height="264.00" viewBox="0 0 724.00 264.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="724.00" height="288.00" viewBox="0 0 724.00 288.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="724.00" height="264.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
-  <path d="M 115.20,72.00 C 115.20,90.50 101.28,96.00 92.00,112.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 198.40,52.00 C 230.86,52.00 206.56,100.00 212.00,132.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 198.40,52.00 C 282.19,52.00 314.56,100.00 392.00,132.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 392.00,132.00 C 290.81,132.00 248.00,180.00 152.00,212.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 392.00,132.00 C 352.00,132.00 356.00,180.00 332.00,212.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 452.00,152.00 C 452.00,168.00 452.00,176.00 452.00,192.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 198.40,52.00 C 351.23,52.00 422.56,100.00 572.00,132.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <rect width="724.00" height="288.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <path d="M 115.20,80.00 C 115.20,98.50 101.28,104.00 92.00,120.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 198.40,56.00 C 234.02,56.00 206.56,108.80 212.00,144.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 198.40,56.00 C 283.46,56.00 314.56,108.80 392.00,144.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 392.00,144.00 C 289.75,144.00 248.00,196.80 152.00,232.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 392.00,144.00 C 349.40,144.00 356.00,196.80 332.00,232.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 452.00,168.00 C 452.00,184.00 452.00,192.00 452.00,208.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 198.40,56.00 C 351.93,56.00 422.56,108.80 572.00,144.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
   <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -31,10 +31,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="166.40" height="40.00" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="83.20" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Product Launch</text>
+    <rect width="166.40" height="48.00" rx="12.00" ry="12.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="83.20" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Product Launch</text>
   </g>
-  <g transform="translate(32.00,112.00)">
+  <g transform="translate(32.00,120.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFE8DC"/>
@@ -53,10 +53,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Story</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Story</text>
   </g>
-  <g transform="translate(212.00,112.00)">
+  <g transform="translate(212.00,120.00)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFF1CD"/>
@@ -75,10 +75,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Message</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Message</text>
   </g>
-  <g transform="translate(392.00,112.00)">
+  <g transform="translate(392.00,120.00)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#DFF6EA"/>
@@ -97,10 +97,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Channels</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Channels</text>
   </g>
-  <g transform="translate(32.00,192.00)">
+  <g transform="translate(32.00,208.00)">
     <defs>
       <linearGradient id="node-4-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#F0E6FF"/>
@@ -119,10 +119,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-4-fill-gradient)" stroke="url(#node-4-stroke-gradient)" stroke-width="1.80" filter="url(#node-4-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Web</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-4-fill-gradient)" stroke="url(#node-4-stroke-gradient)" stroke-width="1.80" filter="url(#node-4-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Web</text>
   </g>
-  <g transform="translate(212.00,192.00)">
+  <g transform="translate(212.00,208.00)">
     <defs>
       <linearGradient id="node-5-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#E2F3FF"/>
@@ -141,10 +141,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-5-fill-gradient)" stroke="url(#node-5-stroke-gradient)" stroke-width="1.80" filter="url(#node-5-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Docs</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-5-fill-gradient)" stroke="url(#node-5-stroke-gradient)" stroke-width="1.80" filter="url(#node-5-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Docs</text>
   </g>
-  <g transform="translate(392.00,192.00)">
+  <g transform="translate(392.00,208.00)">
     <defs>
       <linearGradient id="node-6-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FEE5E5"/>
@@ -163,10 +163,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-6-fill-gradient)" stroke="url(#node-6-stroke-gradient)" stroke-width="1.80" filter="url(#node-6-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Slides</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-6-fill-gradient)" stroke="url(#node-6-stroke-gradient)" stroke-width="1.80" filter="url(#node-6-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Slides</text>
   </g>
-  <g transform="translate(572.00,112.00)">
+  <g transform="translate(572.00,120.00)">
     <defs>
       <linearGradient id="node-7-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#EAF6EB"/>
@@ -185,7 +185,7 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="12.00" ry="12.00" fill="url(#node-7-fill-gradient)" stroke="url(#node-7-stroke-gradient)" stroke-width="1.80" filter="url(#node-7-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Launch</text>
+    <rect width="120.00" height="48.00" rx="12.00" ry="12.00" fill="url(#node-7-fill-gradient)" stroke="url(#node-7-stroke-gradient)" stroke-width="1.80" filter="url(#node-7-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Launch</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-state.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-state.expected.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="184.00" height="344.00" viewBox="0 0 184.00 344.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="184.00" height="376.00" viewBox="0 0 184.00 376.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="184.00" height="344.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
-  <path d="M 92.00,72.00 C 92.00,88.00 92.00,96.00 92.00,112.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 92.00,152.00 C 92.00,168.00 92.00,176.00 92.00,192.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <text x="92.00" y="168.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">start</text>
-  <path d="M 92.00,192.00 C 92.00,176.00 92.00,168.00 92.00,152.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <text x="92.00" y="168.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">stop</text>
-  <path d="M 92.00,232.00 C 92.00,248.00 92.00,256.00 92.00,272.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <rect width="184.00" height="376.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <path d="M 92.00,80.00 C 92.00,96.00 92.00,104.00 92.00,120.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 92.00,168.00 C 92.00,184.00 92.00,192.00 92.00,208.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <text x="92.00" y="184.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">start</text>
+  <path d="M 92.00,208.00 C 92.00,192.00 92.00,184.00 92.00,168.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <text x="92.00" y="184.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">stop</text>
+  <path d="M 92.00,256.00 C 92.00,272.00 92.00,280.00 92.00,296.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
   <g transform="translate(32.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -30,10 +30,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <ellipse cx="60.00" cy="20.00" rx="60.00" ry="20.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">[*]</text>
+    <ellipse cx="60.00" cy="24.00" rx="60.00" ry="24.00" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">[*]</text>
   </g>
-  <g transform="translate(32.00,112.00)">
+  <g transform="translate(32.00,120.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFE8DC"/>
@@ -52,10 +52,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Idle</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Idle</text>
   </g>
-  <g transform="translate(32.00,192.00)">
+  <g transform="translate(32.00,208.00)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFF1CD"/>
@@ -74,10 +74,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Running</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Running</text>
   </g>
-  <g transform="translate(32.00,272.00)">
+  <g transform="translate(32.00,296.00)">
     <defs>
       <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#DFF6EA"/>
@@ -96,7 +96,7 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <ellipse cx="60.00" cy="20.00" rx="60.00" ry="20.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">[*]</text>
+    <ellipse cx="60.00" cy="24.00" rx="60.00" ry="24.00" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">[*]</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-subgraph-presentation-shadow.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-subgraph-presentation-shadow.expected.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="576.00" height="160.00" viewBox="0 0 576.00 160.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="576.00" height="168.00" viewBox="0 0 576.00 168.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="576.00" height="160.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <rect width="576.00" height="168.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
   <defs>
     <linearGradient id="group-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#EDF3FEEB"/>
@@ -23,7 +23,7 @@
       <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
     </filter>
   </defs>
-  <rect x="32.00" y="32.00" width="332.00" height="96.00" rx="12.00" ry="12.00" fill="url(#group-0-fill-gradient)" stroke="url(#group-0-stroke-gradient)" stroke-width="1.80" filter="url(#group-0-soft-shadow)"/>
+  <rect x="32.00" y="32.00" width="332.00" height="104.00" rx="12.00" ry="12.00" fill="url(#group-0-fill-gradient)" stroke="url(#group-0-stroke-gradient)" stroke-width="1.80" filter="url(#group-0-soft-shadow)"/>
   <rect x="42.00" y="42.00" width="143.95" height="23.12" rx="11.56" ry="11.56" fill="#E9EEF2" stroke="#4E7FCA" stroke-width="1.44"/>
   <text x="51.00" y="57.72" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.12" fill="#111827" font-weight="bold">Backend Services</text>
   <defs>
@@ -44,11 +44,11 @@
       <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
     </filter>
   </defs>
-  <rect x="392.00" y="32.00" width="152.00" height="96.00" rx="12.00" ry="12.00" fill="url(#group-1-fill-gradient)" stroke="url(#group-1-stroke-gradient)" stroke-width="1.80" filter="url(#group-1-soft-shadow)"/>
+  <rect x="392.00" y="32.00" width="152.00" height="104.00" rx="12.00" ry="12.00" fill="url(#group-1-fill-gradient)" stroke="url(#group-1-stroke-gradient)" stroke-width="1.80" filter="url(#group-1-soft-shadow)"/>
   <rect x="402.00" y="42.00" width="49.49" height="23.12" rx="11.56" ry="11.56" fill="#E9EEF2" stroke="#4E7FCA" stroke-width="1.44"/>
   <text x="411.00" y="57.72" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.12" fill="#111827" font-weight="bold">data</text>
-  <path d="M 168.00,92.00 C 192.00,92.00 204.00,92.00 228.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 348.00,92.00 C 372.00,92.00 384.00,92.00 408.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 168.00,96.00 C 192.00,96.00 204.00,96.00 228.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 348.00,96.00 C 372.00,96.00 384.00,96.00 408.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
   <g transform="translate(48.00,72.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -68,8 +68,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">API</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">API</text>
   </g>
   <g transform="translate(228.00,72.00)">
     <defs>
@@ -90,8 +90,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Worker</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Worker</text>
   </g>
   <g transform="translate(408.00,72.00)">
     <defs>
@@ -112,7 +112,7 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">DB</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">DB</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="740.00" height="160.00" viewBox="0 0 740.00 160.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="740.00" height="168.00" viewBox="0 0 740.00 168.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="740.00" height="160.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <rect width="740.00" height="168.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
   <defs>
     <linearGradient id="group-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#EDF3FEEB"/>
@@ -23,15 +23,15 @@
       <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
     </filter>
   </defs>
-  <rect x="32.00" y="32.00" width="332.00" height="96.00" rx="12.00" ry="12.00" fill="url(#group-0-fill-gradient)" stroke="url(#group-0-stroke-gradient)" stroke-width="1.80" filter="url(#group-0-soft-shadow)"/>
+  <rect x="32.00" y="32.00" width="332.00" height="104.00" rx="12.00" ry="12.00" fill="url(#group-0-fill-gradient)" stroke="url(#group-0-stroke-gradient)" stroke-width="1.80" filter="url(#group-0-soft-shadow)"/>
   <rect x="42.00" y="42.00" width="104.59" height="23.12" rx="11.56" ry="11.56" fill="#E9EEF2" stroke="#4E7FCA" stroke-width="1.44"/>
   <text x="51.00" y="57.72" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.12" fill="#111827" font-weight="bold">Design Loop</text>
-  <path d="M 168.00,92.00 C 192.00,92.00 204.00,92.00 228.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 348.00,92.00 C 372.00,92.00 384.00,92.00 408.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 528.00,92.00 C 552.00,92.00 564.00,92.00 588.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <text x="558.00" y="88.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">ship</text>
-  <path d="M 408.00,92.00 C 312.00,92.00 264.00,92.00 168.00,92.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <text x="288.00" y="88.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">revise</text>
+  <path d="M 168.00,96.00 C 192.00,96.00 204.00,96.00 228.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 348.00,96.00 C 372.00,96.00 384.00,96.00 408.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 528.00,96.00 C 552.00,96.00 564.00,96.00 588.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <text x="558.00" y="92.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">ship</text>
+  <path d="M 408.00,96.00 C 312.00,96.00 264.00,96.00 168.00,96.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <text x="288.00" y="92.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.60" fill="#4B5563" font-style="italic">revise</text>
   <g transform="translate(48.00,72.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -51,8 +51,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Plan</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Plan</text>
   </g>
   <g transform="translate(228.00,72.00)">
     <defs>
@@ -73,8 +73,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Draft</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Draft</text>
   </g>
   <g transform="translate(408.00,72.00)">
     <defs>
@@ -95,8 +95,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <polygon points="60.00,0 120.00,20.00 60.00,40.00 0,20.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Review</text>
+    <polygon points="60.00,0 120.00,24.00 60.00,48.00 0,24.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Review</text>
   </g>
   <g transform="translate(588.00,72.00)">
     <defs>
@@ -117,7 +117,7 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Publish</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Publish</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="544.00" height="320.00" viewBox="0 0 544.00 320.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="544.00" height="344.00" viewBox="0 0 544.00 344.00">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#173F6D"/>
     </marker>
   </defs>
-  <rect width="544.00" height="320.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
+  <rect width="544.00" height="344.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
   <text x="272.00" y="28.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="20.00" font-weight="bold" fill="#111827">Product Roadmap</text>
-  <path d="M 92.00,100.00 C 92.00,116.00 92.00,124.00 92.00,140.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 92.00,100.00 C 92.00,148.00 92.00,172.00 92.00,220.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 272.00,100.00 C 272.00,116.00 272.00,124.00 272.00,140.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 452.00,100.00 C 452.00,116.00 452.00,124.00 452.00,140.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 452.00,100.00 C 452.00,148.00 452.00,172.00 452.00,220.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 92.00,108.00 C 92.00,124.00 92.00,132.00 92.00,148.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 92.00,108.00 C 92.00,159.20 92.00,184.80 92.00,236.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 272.00,108.00 C 272.00,124.00 272.00,132.00 272.00,148.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 452.00,108.00 C 452.00,124.00 452.00,132.00 452.00,148.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 452.00,108.00 C 452.00,159.20 452.00,184.80 452.00,236.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
   <g transform="translate(32.00,60.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -30,10 +30,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q1</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q1</text>
   </g>
-  <g transform="translate(32.00,140.00)">
+  <g transform="translate(32.00,148.00)">
     <defs>
       <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFE8DC"/>
@@ -52,10 +52,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Research</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Research</text>
   </g>
-  <g transform="translate(32.00,220.00)">
+  <g transform="translate(32.00,236.00)">
     <defs>
       <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FFF1CD"/>
@@ -74,8 +74,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Prototype</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Prototype</text>
   </g>
   <g transform="translate(212.00,60.00)">
     <defs>
@@ -96,10 +96,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q2</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q2</text>
   </g>
-  <g transform="translate(212.00,140.00)">
+  <g transform="translate(212.00,148.00)">
     <defs>
       <linearGradient id="node-4-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#F0E6FF"/>
@@ -118,8 +118,8 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-4-fill-gradient)" stroke="url(#node-4-stroke-gradient)" stroke-width="1.80" filter="url(#node-4-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Beta</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-4-fill-gradient)" stroke="url(#node-4-stroke-gradient)" stroke-width="1.80" filter="url(#node-4-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Beta</text>
   </g>
   <g transform="translate(392.00,60.00)">
     <defs>
@@ -140,10 +140,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-5-fill-gradient)" stroke="url(#node-5-stroke-gradient)" stroke-width="1.80" filter="url(#node-5-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q3</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-5-fill-gradient)" stroke="url(#node-5-stroke-gradient)" stroke-width="1.80" filter="url(#node-5-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Q3</text>
   </g>
-  <g transform="translate(392.00,140.00)">
+  <g transform="translate(392.00,148.00)">
     <defs>
       <linearGradient id="node-6-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#FEE5E5"/>
@@ -162,10 +162,10 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-6-fill-gradient)" stroke="url(#node-6-stroke-gradient)" stroke-width="1.80" filter="url(#node-6-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">GA</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-6-fill-gradient)" stroke="url(#node-6-stroke-gradient)" stroke-width="1.80" filter="url(#node-6-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">GA</text>
   </g>
-  <g transform="translate(392.00,220.00)">
+  <g transform="translate(392.00,236.00)">
     <defs>
       <linearGradient id="node-7-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
         <stop offset="0%" stop-color="#EAF6EB"/>
@@ -184,7 +184,7 @@
         <feDropShadow dx="0.00" dy="1.55" stdDeviation="1.65" flood-color="#0F172A" flood-opacity="0.16"/>
       </filter>
     </defs>
-    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-7-fill-gradient)" stroke="url(#node-7-stroke-gradient)" stroke-width="1.80" filter="url(#node-7-soft-shadow)"/>
-    <text x="60.00" y="25.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Scale</text>
+    <rect width="120.00" height="48.00" rx="0" ry="0" fill="url(#node-7-fill-gradient)" stroke="url(#node-7-stroke-gradient)" stroke-width="1.80" filter="url(#node-7-soft-shadow)"/>
+    <text x="60.00" y="29.60" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="16.00" fill="#111827">Scale</text>
   </g>
 </svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-venn.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-venn.expected.svg
@@ -161,7 +161,7 @@
         <stop offset="100%" stop-color="#8C4118"/>
       </linearGradient>
     </defs>
-    <rect x="-20.40" y="-10.40" width="40.80" height="16.25" rx="4.55" ry="4.55" fill="url(#node-10-fill-gradient)" stroke="url(#node-10-stroke-gradient)" stroke-width="1.50" fill-opacity="0.55"/>
+    <rect x="-20.40" y="-8.45" width="40.80" height="16.25" rx="4.55" ry="4.55" fill="url(#node-10-fill-gradient)" stroke="url(#node-10-stroke-gradient)" stroke-width="1.50" fill-opacity="0.55"/>
     <text x="0.00" y="4.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#0F172A">Heat</text>
   </g>
 </svg>

--- a/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
+++ b/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
@@ -121,6 +121,36 @@ public class DefaultLayoutEngineTests
     }
 
     [Fact]
+    public void Layout_VeryLongLabel_CapsWidthAndWrapsLines()
+    {
+        var diagram = new Diagram()
+            .AddNode(new Node("long", "This is a deliberately long label that should wrap instead of producing an absurdly wide node box in the rendered diagram"));
+
+        _engine.Layout(diagram, _theme);
+
+        var node = diagram.Nodes["long"];
+        Assert.True(node.Width <= diagram.LayoutHints.MaxNodeWidth, $"node width {node.Width} should be <= max width {diagram.LayoutHints.MaxNodeWidth}");
+        Assert.True(node.Height > diagram.LayoutHints.MinNodeHeight, $"node height {node.Height} should exceed min height {diagram.LayoutHints.MinNodeHeight}");
+        Assert.True(node.Label.Lines?.Length > 1, "long label should wrap into multiple lines");
+    }
+
+    [Fact]
+    public void Layout_WrappedNode_DoesNotOverlapNextLayer_Vertical()
+    {
+        var diagram = new Diagram();
+        diagram.AddNode(new Node("a", "This is a deliberately long label that should wrap across multiple lines"))
+               .AddNode(new Node("b", "Next"))
+               .AddEdge(new Edge("a", "b"));
+
+        _engine.Layout(diagram, _theme);
+
+        var a = diagram.Nodes["a"];
+        var b = diagram.Nodes["b"];
+        Assert.True(b.Y >= a.Y + a.Height + diagram.LayoutHints.VerticalSpacing,
+            $"node b at {b.Y} should be below node a bottom {a.Y + a.Height} plus spacing {diagram.LayoutHints.VerticalSpacing}");
+    }
+
+    [Fact]
     public void Layout_VariableWidths_PreservesGapBetweenLayers_Horizontal()
     {
         // Running-offset positioning: a wide node in column 0 should push column 1

--- a/tests/DiagramForge.Tests/Models/DiagramModelTests.cs
+++ b/tests/DiagramForge.Tests/Models/DiagramModelTests.cs
@@ -104,6 +104,7 @@ public class DiagramModelTests
         Assert.True(hints.HorizontalSpacing > 0);
         Assert.True(hints.VerticalSpacing > 0);
         Assert.True(hints.MinNodeWidth > 0);
+        Assert.True(hints.MaxNodeWidth > hints.MinNodeWidth);
         Assert.True(hints.MinNodeHeight > 0);
     }
 

--- a/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
+++ b/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
@@ -269,6 +269,19 @@ public class SvgRendererTests
     }
 
     [Fact]
+    public void Render_WrappedLongLabel_UsesTspans()
+    {
+        var diagram = BuildAndLayout(new Diagram()
+            .AddNode(new Node("A", "This is a deliberately long label that should wrap instead of staying on a single line")));
+
+        string svg = _renderer.Render(diagram, _theme);
+
+        Assert.Contains("<tspan", svg);
+        Assert.True(svg.Split("<tspan", StringSplitOptions.None).Length > 2, "wrapped label should render as multiple tspans");
+        Assert.Contains("This is a deliberately", svg);
+    }
+
+    [Fact]
     public void Render_PyramidSegmentNode_UsesPolygon()
     {
         var node = new Node("node_0", "Vision")


### PR DESCRIPTION
Closes #7.

## Summary

Add a `MaxNodeWidth` cap with server-side line wrapping for long node labels, plus variable-height node layout so wrapped labels render without overlap.

## What changed

- add `LayoutHints.MaxNodeWidth` with a default of `240`
- store computed wrapped label lines on `Label` so layout and rendering agree
- wrap long labels server-side using word-first breaking with character fallback for long tokens
- grow node height to fit wrapped text
- update layout paths that assumed fixed node heights so wrapped nodes do not overlap
- render wrapped labels as multi-line SVG text using `<tspan>` elements
- add focused unit coverage and a new long-label snapshot fixture
- refresh affected snapshot baselines where the shared node-height behavior changed

## Why

The existing text-aware sizing work prevented clipping by growing nodes indefinitely. This change adds a practical width cap and a rendering strategy for overflow, so long labels stay readable without blowing out the entire diagram width.

## Testing

- `dotnet test tests/DiagramForge.Tests/DiagramForge.Tests.csproj`
- `dotnet test tests/DiagramForge.E2ETests/DiagramForge.E2ETests.csproj --filter "SnapshotTests"`