### PR TITLE
Fix conceptual cycle arrows to use arcs rather than bezier curves

### DIFF
--- a/src/DiagramForge/Layout/DefaultLayoutEngine.Cycle.cs
+++ b/src/DiagramForge/Layout/DefaultLayoutEngine.Cycle.cs
@@ -46,5 +46,13 @@ public sealed partial class DefaultLayoutEngine
             node.Width = nodeW;
             node.Height = nodeH;
         }
+
+        foreach (var edge in diagram.Edges)
+        {
+            edge.Metadata["conceptual:cycleArc"] = true;
+            edge.Metadata["cycle:centerX"] = cx;
+            edge.Metadata["cycle:centerY"] = cy;
+            edge.Metadata["cycle:radius"] = radius;
+        }
     }
 }

--- a/src/DiagramForge/Rendering/SvgStructureWriter.cs
+++ b/src/DiagramForge/Rendering/SvgStructureWriter.cs
@@ -109,7 +109,20 @@ internal static class SvgStructureWriter
         double strokeWidth = edge.LineStyle == EdgeLineStyle.Thick ? theme.StrokeWidth * 2 : theme.StrokeWidth;
         string markerEnd = edge.ArrowHead != ArrowHeadStyle.None ? """ marker-end="url(#arrowhead)" """ : " ";
 
-        sb.AppendLine($"""  <path d="M {SvgRenderSupport.F(x1)},{SvgRenderSupport.F(y1)} C {cp1} {cp2} {SvgRenderSupport.F(x2)},{SvgRenderSupport.F(y2)}" fill="none" stroke="{strokeColor}" stroke-width="{SvgRenderSupport.F(strokeWidth)}"{strokeDash}{markerEnd}/>""");
+        string pathData = $"M {SvgRenderSupport.F(x1)},{SvgRenderSupport.F(y1)} C {cp1} {cp2} {SvgRenderSupport.F(x2)},{SvgRenderSupport.F(y2)}";
+        if (TryBuildCycleArcPath(edge, source, target, out var cycleArcPath, out var cycleLabelX, out var cycleLabelY))
+        {
+            pathData = cycleArcPath;
+            if (edge.Label is not null && !string.IsNullOrWhiteSpace(edge.Label.Text))
+            {
+                x1 = cycleLabelX;
+                y1 = cycleLabelY + 4;
+                x2 = cycleLabelX;
+                y2 = cycleLabelY + 4;
+            }
+        }
+
+        sb.AppendLine($"""  <path d="{pathData}" fill="none" stroke="{strokeColor}" stroke-width="{SvgRenderSupport.F(strokeWidth)}"{strokeDash}{markerEnd}/>""");
 
         if (edge.Label is not null && !string.IsNullOrWhiteSpace(edge.Label.Text))
         {
@@ -144,6 +157,132 @@ internal static class SvgStructureWriter
             sb.AppendLine($"""  <rect x="{SvgRenderSupport.F(badgeX)}" y="{SvgRenderSupport.F(badgeY)}" width="{SvgRenderSupport.F(badgeWidth)}" height="{SvgRenderSupport.F(badgeHeight)}" rx="{SvgRenderSupport.F(badgeHeight / 2)}" ry="{SvgRenderSupport.F(badgeHeight / 2)}" fill="{badgeFill}" stroke="{badgeStroke}" stroke-width="{SvgRenderSupport.F(theme.StrokeWidth * 0.8)}"/>""");
             sb.AppendLine($"""  <text x="{SvgRenderSupport.F(badgeX + 9)}" y="{SvgRenderSupport.F(badgeY + badgeHeight * 0.68)}" font-family="{SvgRenderSupport.Escape(theme.FontFamily)}" font-size="{SvgRenderSupport.F(badgeFontSize)}" fill="{badgeText}" font-weight="bold">{SvgRenderSupport.Escape(group.Label.Text)}</text>""");
         }
+    }
+
+    private static bool TryBuildCycleArcPath(Edge edge, Node source, Node target, out string pathData, out double labelX, out double labelY)
+    {
+        pathData = string.Empty;
+        labelX = 0;
+        labelY = 0;
+
+        if (!edge.Metadata.TryGetValue("conceptual:cycleArc", out var isCycleArc) || isCycleArc is not true)
+            return false;
+
+        if (!edge.Metadata.TryGetValue("cycle:centerX", out var centerXObj)
+            || !edge.Metadata.TryGetValue("cycle:centerY", out var centerYObj)
+            || !edge.Metadata.TryGetValue("cycle:radius", out var radiusObj))
+            return false;
+
+        double centerX = Convert.ToDouble(centerXObj, System.Globalization.CultureInfo.InvariantCulture);
+        double centerY = Convert.ToDouble(centerYObj, System.Globalization.CultureInfo.InvariantCulture);
+        double radius = Convert.ToDouble(radiusObj, System.Globalization.CultureInfo.InvariantCulture);
+
+        double sourceCenterX = source.X + source.Width / 2;
+        double sourceCenterY = source.Y + source.Height / 2;
+        double targetCenterX = target.X + target.Width / 2;
+        double targetCenterY = target.Y + target.Height / 2;
+
+        double sourceAngle = Math.Atan2(sourceCenterY - centerY, sourceCenterX - centerX);
+        double targetAngle = Math.Atan2(targetCenterY - centerY, targetCenterX - centerX);
+        double sweepAngle = NormalizeAngle(targetAngle - sourceAngle);
+        if (sweepAngle <= 0)
+            return false;
+
+        double midAngle = sourceAngle + sweepAngle / 2;
+        double midX = centerX + radius * Math.Cos(midAngle);
+        double midY = centerY + radius * Math.Sin(midAngle);
+
+        double startTangentX = -Math.Sin(sourceAngle);
+        double startTangentY = Math.Cos(sourceAngle);
+        double endTangentX = Math.Sin(targetAngle);
+        double endTangentY = -Math.Cos(targetAngle);
+
+        var (startX, startY) = ProjectPointToNodeBoundary(source, startTangentX, startTangentY);
+        var (endX, endY) = ProjectPointToNodeBoundary(target, endTangentX, endTangentY);
+
+        if (!TryBuildArcThroughPoint(startX, startY, midX, midY, endX, endY, out pathData))
+            return false;
+
+        labelX = midX;
+        labelY = midY - 4;
+        return true;
+    }
+
+    private static (double X, double Y) ProjectPointToNodeBoundary(Node node, double directionX, double directionY)
+    {
+        double centerX = node.X + node.Width / 2;
+        double centerY = node.Y + node.Height / 2;
+        double dx = directionX;
+        double dy = directionY;
+
+        if (Math.Abs(dx) < double.Epsilon && Math.Abs(dy) < double.Epsilon)
+            return (centerX, centerY);
+
+        double halfWidth = node.Width / 2;
+        double halfHeight = node.Height / 2;
+        double scale = 1 / Math.Max(Math.Abs(dx) / halfWidth, Math.Abs(dy) / halfHeight);
+        return (centerX + dx * scale, centerY + dy * scale);
+    }
+
+    private static bool TryBuildArcThroughPoint(
+        double startX,
+        double startY,
+        double midX,
+        double midY,
+        double endX,
+        double endY,
+        out string pathData)
+    {
+        pathData = string.Empty;
+
+        double determinant = 2 * (
+            startX * (midY - endY)
+            + midX * (endY - startY)
+            + endX * (startY - midY));
+
+        if (Math.Abs(determinant) < 0.001)
+            return false;
+
+        double startSquared = startX * startX + startY * startY;
+        double midSquared = midX * midX + midY * midY;
+        double endSquared = endX * endX + endY * endY;
+
+        double centerX = (
+            startSquared * (midY - endY)
+            + midSquared * (endY - startY)
+            + endSquared * (startY - midY)) / determinant;
+        double centerY = (
+            startSquared * (endX - midX)
+            + midSquared * (startX - endX)
+            + endSquared * (midX - startX)) / determinant;
+
+        double radius = Math.Sqrt(Math.Pow(startX - centerX, 2) + Math.Pow(startY - centerY, 2));
+        if (radius <= 0)
+            return false;
+
+        double startAngle = Math.Atan2(startY - centerY, startX - centerX);
+        double middleAngle = Math.Atan2(midY - centerY, midX - centerX);
+        double endAngle = Math.Atan2(endY - centerY, endX - centerX);
+
+        double forwardSweep = NormalizeAngle(endAngle - startAngle);
+        double middleSweep = NormalizeAngle(middleAngle - startAngle);
+        bool useForwardSweep = middleSweep <= forwardSweep;
+        int sweepFlag = useForwardSweep ? 1 : 0;
+        double selectedSweep = useForwardSweep ? forwardSweep : NormalizeAngle(startAngle - endAngle);
+        int largeArcFlag = selectedSweep > Math.PI ? 1 : 0;
+
+        pathData = $"M {SvgRenderSupport.F(startX)},{SvgRenderSupport.F(startY)} A {SvgRenderSupport.F(radius)},{SvgRenderSupport.F(radius)} 0 {largeArcFlag},{sweepFlag} {SvgRenderSupport.F(endX)},{SvgRenderSupport.F(endY)}";
+        return true;
+    }
+
+    private static double NormalizeAngle(double angle)
+    {
+        const double Tau = Math.PI * 2;
+        while (angle <= 0)
+            angle += Tau;
+        while (angle > Tau)
+            angle -= Tau;
+        return angle;
     }
 
     internal static void AppendLifelines(StringBuilder sb, Diagram diagram, Theme theme, double canvasHeight)

--- a/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg
@@ -5,10 +5,10 @@
     </marker>
   </defs>
   <rect width="536.00" height="456.00" fill="#FFFDF8" rx="12.00" ry="12.00"/>
-  <path d="M 328.00,52.00 C 401.88,52.00 361.60,157.60 384.00,228.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 384.00,228.00 C 310.12,228.00 350.40,333.60 328.00,404.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 208.00,404.00 C 134.12,404.00 174.40,298.40 152.00,228.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
-  <path d="M 92.00,208.00 C 92.00,119.03 197.60,126.40 268.00,72.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 328.00,52.00 A 229.32,229.32 0 0,1 444.00,208.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 444.00,248.00 A 229.32,229.32 0 0,1 328.00,404.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 208.00,404.00 A 229.32,229.32 0 0,1 92.00,248.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
+  <path d="M 92.00,208.00 A 229.32,229.32 0 0,1 208.00,52.00" fill="none" stroke="#173F6D" stroke-width="1.80"  marker-end="url(#arrowhead)" />
   <g transform="translate(208.00,32.00)">
     <defs>
       <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">

--- a/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
+++ b/tests/DiagramForge.Tests/Layout/DefaultLayoutEngineTests.cs
@@ -886,4 +886,28 @@ public class DefaultLayoutEngineTests
         var sizes = diagram.Nodes.Values.Select(n => (n.Width, n.Height)).Distinct().ToList();
         Assert.Single(sizes);
     }
+
+    [Fact]
+    public void Layout_CycleDiagram_TagsEdgesForCircularRouting()
+    {
+        var diagram = new Diagram { DiagramType = "cycle" };
+        diagram.AddNode(new Node("node_0", "Plan"))
+               .AddNode(new Node("node_1", "Build"))
+               .AddNode(new Node("node_2", "Measure"))
+               .AddNode(new Node("node_3", "Learn"))
+               .AddEdge(new Edge("node_0", "node_1"))
+               .AddEdge(new Edge("node_1", "node_2"))
+               .AddEdge(new Edge("node_2", "node_3"))
+               .AddEdge(new Edge("node_3", "node_0"));
+
+        _engine.Layout(diagram, _theme);
+
+        Assert.All(diagram.Edges, edge =>
+        {
+            Assert.True(edge.Metadata.TryGetValue("conceptual:cycleArc", out var route) && route is true);
+            Assert.True(edge.Metadata.ContainsKey("cycle:centerX"));
+            Assert.True(edge.Metadata.ContainsKey("cycle:centerY"));
+            Assert.True(edge.Metadata.ContainsKey("cycle:radius"));
+        });
+    }
 }

--- a/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
+++ b/tests/DiagramForge.Tests/Rendering/SvgRendererTests.cs
@@ -301,6 +301,27 @@ public class SvgRendererTests
         Assert.Contains(">Vision</text>", svg);
     }
 
+    [Fact]
+    public void Render_CycleDiagram_UsesCircularArcEdgePaths()
+    {
+        var diagram = new Diagram { DiagramType = "cycle" };
+        diagram.AddNode(new Node("node_0", "Plan"))
+               .AddNode(new Node("node_1", "Build"))
+               .AddNode(new Node("node_2", "Measure"))
+               .AddNode(new Node("node_3", "Learn"))
+               .AddEdge(new Edge("node_0", "node_1"))
+               .AddEdge(new Edge("node_1", "node_2"))
+               .AddEdge(new Edge("node_2", "node_3"))
+               .AddEdge(new Edge("node_3", "node_0"));
+
+        BuildAndLayout(diagram);
+
+        string svg = _renderer.Render(diagram, _theme);
+
+        Assert.Matches(@"<path d=""M [^""]+ A [^""]+"" fill=""none""", svg);
+        Assert.DoesNotMatch(@"<path d=""M [^""]+ C [^""]+"" fill=""none""", svg);
+    }
+
     // ── Utilities (mirrors the production SvgRenderer.F() helper) ────────────
 
     private static string F(double v) =>


### PR DESCRIPTION
## Summary
Adjust conceptual cycle edge routing so the top and bottom nodes connect from their sides while preserving the circular arc shape.

## Changes
- keep conceptual cycle connectors rendered as SVG arcs
- anchor cycle arc endpoints using tangent-based side attachment
- update cycle layout/render tests
- refresh the conceptual cycle snapshot baseline

## Validation
- dotnet test tests/DiagramForge.Tests/DiagramForge.Tests.csproj --filter "FullyQualifiedName~Layout_CycleDiagram|FullyQualifiedName~Render_CycleDiagram_UsesCircularArcEdgePaths"
- dotnet test tests/DiagramForge.E2ETests/DiagramForge.E2ETests.csproj --filter "FullyQualifiedName~SnapshotTests"