### PR TITLE
Update README gallery to linked diagram and theme tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
 <table cellpadding="12">
   <tr>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg" alt="Flowchart" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-edge-labels.expected.svg" alt="Flowchart" height="96" />
       </a>
       <br />
       <sub>Flowchart</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg" alt="Block diagram" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-block.expected.svg" alt="Block diagram" height="96" />
       </a>
       <br />
       <sub>Block</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg" alt="Sequence" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-sequence.expected.svg" alt="Sequence" height="96" />
       </a>
       <br />
       <sub>Sequence</sub>
@@ -38,22 +38,22 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-architecture.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-architecture.expected.svg" alt="Architecture" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-architecture.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-architecture.expected.svg" alt="Architecture" height="96" />
       </a>
       <br />
       <sub>Architecture</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg" alt="Mindmap" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-mindmap.expected.svg" alt="Mindmap" height="96" />
       </a>
       <br />
       <sub>Mindmap</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg" alt="Timeline" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-timeline.expected.svg" alt="Timeline" height="96" />
       </a>
       <br />
       <sub>Timeline</sub>
@@ -61,22 +61,22 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-venn-two-set.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-venn-two-set.expected.svg" alt="Venn diagram" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-venn-two-set.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-venn-two-set.expected.svg" alt="Venn diagram" height="96" />
       </a>
       <br />
       <sub>Venn</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg" alt="XY chart" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-xychart.expected.svg" alt="XY chart" height="96" />
       </a>
       <br />
       <sub>XY Chart</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg" alt="Conceptual cycle" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-cycle.expected.svg" alt="Conceptual cycle" height="96" />
       </a>
       <br />
       <sub>Conceptual Cycle</sub>
@@ -84,22 +84,22 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg" alt="Conceptual matrix" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-matrix.expected.svg" alt="Conceptual matrix" height="96" />
       </a>
       <br />
       <sub>Conceptual Matrix</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/conceptual-pillars.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/conceptual-pillars.expected.svg" alt="Conceptual pillars" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-pillars.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-pillars.expected.svg" alt="Conceptual pillars" height="96" />
       </a>
       <br />
       <sub>Conceptual Pillars</sub>
     </td>
     <td align="center" valign="top" width="33%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg" alt="Conceptual pyramid" height="96" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/conceptual-pyramid.expected.svg" alt="Conceptual pyramid" height="96" />
       </a>
       <br />
       <sub>Conceptual Pyramid</sub>
@@ -112,15 +112,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
 <table cellpadding="16">
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-default.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-default.expected.svg" alt="Default theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-default.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-default.expected.svg" alt="Default theme" width="400" />
       </a>
       <br />
       <sub>Default</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-forest.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-forest.expected.svg" alt="Forest theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-forest.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-forest.expected.svg" alt="Forest theme" width="400" />
       </a>
       <br />
       <sub>Forest</sub>
@@ -128,15 +128,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-neutral.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-neutral.expected.svg" alt="Neutral theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-neutral.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-neutral.expected.svg" alt="Neutral theme" width="400" />
       </a>
       <br />
       <sub>Neutral</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-dracula.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-dracula.expected.svg" alt="Dracula theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-dracula.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-dracula.expected.svg" alt="Dracula theme" width="400" />
       </a>
       <br />
       <sub>Dracula</sub>
@@ -144,15 +144,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-dark.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-dark.expected.svg" alt="GitHub Dark theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-dark.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-dark.expected.svg" alt="GitHub Dark theme" width="400" />
       </a>
       <br />
       <sub>GitHub Dark</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-light.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-light.expected.svg" alt="GitHub Light theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-light.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-github-light.expected.svg" alt="GitHub Light theme" width="400" />
       </a>
       <br />
       <sub>GitHub Light</sub>
@@ -160,15 +160,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-latte.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-latte.expected.svg" alt="Catppuccin Latte theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-latte.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-latte.expected.svg" alt="Catppuccin Latte theme" width="400" />
       </a>
       <br />
       <sub>Catppuccin Latte</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-mocha.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-mocha.expected.svg" alt="Catppuccin Mocha theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-mocha.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-catppuccin-mocha.expected.svg" alt="Catppuccin Mocha theme" width="400" />
       </a>
       <br />
       <sub>Catppuccin Mocha</sub>
@@ -176,15 +176,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg" alt="Presentation theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-presentation.expected.svg" alt="Presentation theme" width="400" />
       </a>
       <br />
       <sub>Presentation</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-tokyo-night.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-tokyo-night.expected.svg" alt="Tokyo Night theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-tokyo-night.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-tokyo-night.expected.svg" alt="Tokyo Night theme" width="400" />
       </a>
       <br />
       <sub>Tokyo Night</sub>
@@ -192,15 +192,15 @@ Representative snapshot fixtures from the E2E suite. Click any thumbnail to open
   </tr>
   <tr>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-one-dark.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-one-dark.expected.svg" alt="One Dark theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-one-dark.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-one-dark.expected.svg" alt="One Dark theme" width="400" />
       </a>
       <br />
       <sub>One Dark</sub>
     </td>
     <td align="center" valign="top" width="50%">
-      <a href="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-zinc-light.expected.svg">
-        <img src="tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-zinc-light.expected.svg" alt="Zinc Light theme" width="400" />
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-zinc-light.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-zinc-light.expected.svg" alt="Zinc Light theme" width="400" />
       </a>
       <br />
       <sub>Zinc Light</sub>


### PR DESCRIPTION
## Summary
- replace the composite README gallery SVGs with curated linked tables
- add a broader diagram types gallery sourced from E2E fixture SVGs
- add a larger built-in themes gallery so theme differences are visible inline
- tune diagram thumbnail sizing for a better balance between GitHub rendering and markdown preview

## Testing
- validated README markdown after each update with workspace diagnostics
- manually previewed the gallery layout in a browser against a GitHub-like content width