### PR TITLE
Add NuGet-specific package readme

### DIFF
--- a/doc/PackageReadme.md
+++ b/doc/PackageReadme.md
@@ -1,0 +1,73 @@
+# DiagramForge
+
+Text in, SVG out. DiagramForge is a .NET library and CLI for rendering diagram text to real SVG without a browser, JavaScript runtime, or headless Chrome.
+
+DiagramForge focuses on the cases where Mermaid-style diagram authoring is useful, but browser-generated SVG is not: PowerPoint decks, Keynote slides, Inkscape workflows, docs pipelines, and image conversion with tools like librsvg.
+
+![Diagram gallery](https://raw.githubusercontent.com/jongalloway/DiagramForge/main/doc/diagram-gallery.svg)
+
+## Why DiagramForge
+
+- Real SVG output with native `text` elements
+- No browser, Node.js, or headless Chrome dependency
+- Deterministic rendering suitable for snapshot testing
+- Mermaid subset support plus presentation-oriented conceptual layouts
+- Built-in themes, JSON themes, palette overrides, and embedded frontmatter styling
+
+![Theme gallery](https://raw.githubusercontent.com/jongalloway/DiagramForge/main/doc/theme-gallery.svg)
+
+## Install
+
+DiagramForge targets `.NET 10`.
+
+### Library
+
+```bash
+dotnet add package DiagramForge
+```
+
+### CLI tool
+
+```bash
+dotnet tool install -g DiagramForge.Tool
+```
+
+## Basic usage
+
+```csharp
+using DiagramForge;
+
+var renderer = new DiagramRenderer();
+string svg = renderer.Render("""
+flowchart LR
+  A[Plan] --> B[Build]
+  B --> C[Ship]
+""");
+```
+
+## CLI usage
+
+```bash
+diagramforge diagram.mmd -o diagram.svg
+diagramforge diagram.mmd --theme dracula --transparent -o overlay.svg
+```
+
+## Supported today
+
+- Mermaid subset: flowchart, block, sequence, state, mindmap, timeline, venn, architecture, and xychart
+- Conceptual DSL: matrix, pyramid, cycle, and pillars
+- Theme presets, theme JSON files, palette overrides, and frontmatter styling
+
+DiagramForge intentionally implements a focused Mermaid subset rather than full Mermaid.js parity.
+
+## Documentation
+
+- Full project README: [github.com/jongalloway/DiagramForge](https://github.com/jongalloway/DiagramForge)
+- Theming guide: [Theming](https://github.com/jongalloway/DiagramForge/blob/main/doc/theming.md)
+- Frontmatter guide: [Frontmatter](https://github.com/jongalloway/DiagramForge/blob/main/doc/frontmatter.md)
+- Product scope and roadmap: [PRD](https://github.com/jongalloway/DiagramForge/blob/main/doc/prd.md)
+
+## Feedback
+
+- Issues: [github.com/jongalloway/DiagramForge/issues](https://github.com/jongalloway/DiagramForge/issues)
+- Source: [github.com/jongalloway/DiagramForge](https://github.com/jongalloway/DiagramForge)

--- a/src/DiagramForge.Cli/DiagramForge.Cli.csproj
+++ b/src/DiagramForge.Cli/DiagramForge.Cli.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="" Link="README.md" />
+    <None Include="..\..\doc\PackageReadme.md" Pack="true" PackagePath="" Link="PackageReadme.md" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Link="LICENSE" />
   </ItemGroup>
 
@@ -25,7 +26,7 @@
     <Description>CLI and .NET tool wrapper for rendering diagrams to SVG with DiagramForge.</Description>
     <Authors>Jon Galloway</Authors>
     <PackageTags>diagram svg mermaid cli dotnet-tool</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/jongalloway/DiagramForge</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/DiagramForge/DiagramForge.csproj
+++ b/src/DiagramForge/DiagramForge.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="" Link="README.md" />
+    <None Include="..\..\doc\PackageReadme.md" Pack="true" PackagePath="" Link="PackageReadme.md" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Link="LICENSE" />
   </ItemGroup>
 
@@ -20,7 +21,7 @@
     <Description>Text-to-SVG diagram renderer for Mermaid subsets and conceptual diagrams.</Description>
     <Authors>Jon Galloway</Authors>
     <PackageTags>diagram svg mermaid rendering powerpoint</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/jongalloway/DiagramForge</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Summary

Adds a NuGet-specific package readme and updates both packages to use it instead of the GitHub-oriented repository README.

## What changed

- add `doc/PackageReadme.md`
- update `DiagramForge.csproj` to pack `doc/PackageReadme.md` as `PackageReadme.md`
- update `DiagramForge.Cli.csproj` to pack `doc/PackageReadme.md` as `PackageReadme.md`
- switch both packages from `PackageReadmeFile=README.md` to `PackageReadmeFile=PackageReadme.md`

## Why

The repository README is optimized for GitHub and uses HTML-heavy gallery layout that does not render well on NuGet. The package readme is kept smaller and uses plain Markdown plus allowed image hosts so the NuGet package page looks clean.

## Validation

- `dotnet build DiagramForge.slnx --configuration Release`
- markdown / project file diagnostics are clean