### PR TITLE
Prefer dnx for CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,13 @@ DiagramForge targets `.NET 10`. For local development and the CLI tool, use SDK/
 dotnet add package DiagramForge
 ```
 
-### CLI (.NET tool)
+### CLI (`dnx`)
 
 ```sh
-dotnet tool install -g DiagramForge.Tool
+dnx DiagramForge.Tool --help
 ```
+
+With `.NET 10`, `dnx` can run the tool package directly without a prior install.
 
 ## Library usage
 
@@ -330,7 +332,7 @@ Implement `IDiagramParser`. You get two methods: `CanParse(string)` for sniffing
 ## CLI usage
 
 ```text
-diagramforge <input-file> [options]
+dnx DiagramForge.Tool <input-file> [options]
 ```
 
 | Argument | Description |
@@ -349,13 +351,13 @@ CLI precedence mirrors the library API: frontmatter can define theme and styling
 
 ```sh
 # write to file
-diagramforge diagram.mmd -o diagram.svg
+dnx DiagramForge.Tool diagram.mmd -o diagram.svg
 
 # render for overlay on an existing page background
-diagramforge diagram.mmd --theme dracula --transparent -o overlay.svg
+dnx DiagramForge.Tool diagram.mmd --theme dracula --transparent -o overlay.svg
 
 # pipe to something else
-diagramforge diagram.txt | rsvg-convert -o diagram.png
+dnx DiagramForge.Tool diagram.txt | rsvg-convert -o diagram.png
 ```
 
 ## Supported syntax

--- a/doc/PackageReadme.md
+++ b/doc/PackageReadme.md
@@ -26,11 +26,13 @@ DiagramForge targets `.NET 10`.
 dotnet add package DiagramForge
 ```
 
-### CLI tool
+### CLI (`dnx`)
 
 ```bash
-dotnet tool install -g DiagramForge.Tool
+dnx DiagramForge.Tool --help
 ```
+
+With `.NET 10`, `dnx` can run the tool package directly without a prior install.
 
 ## Basic usage
 
@@ -48,8 +50,8 @@ flowchart LR
 ## CLI usage
 
 ```bash
-diagramforge diagram.mmd -o diagram.svg
-diagramforge diagram.mmd --theme dracula --transparent -o overlay.svg
+dnx DiagramForge.Tool diagram.mmd -o diagram.svg
+dnx DiagramForge.Tool diagram.mmd --theme dracula --transparent -o overlay.svg
 ```
 
 ## Supported today

--- a/src/DiagramForge.Cli/Program.cs
+++ b/src/DiagramForge.Cli/Program.cs
@@ -165,8 +165,8 @@ static void PrintHelp()
         "DiagramForge — Diagram text to SVG renderer",
         string.Empty,
         "Usage:",
-        "  diagramforge <input-file> [options]",
-        "  diagramforge --help",
+        "  dnx DiagramForge.Tool <input-file> [options]",
+        "  dnx DiagramForge.Tool --help",
         string.Empty,
         "Arguments:",
         "  <input-file>                  Path to the diagram source file (Mermaid or Conceptual DSL)",
@@ -185,11 +185,11 @@ static void PrintHelp()
         "  conceptual                    Matrix, Pyramid",
         string.Empty,
         "Examples:",
-        "  diagramforge diagram.mmd --output diagram.svg",
-        "  diagramforge diagram.mmd --theme dark --output diagram.svg",
-        "  diagramforge diagram.mmd --theme dark --palette '[\"#FF6B6B\",\"#4ECDC4\",\"#45B7D1\"]' -o out.svg",
-        "  diagramforge diagram.mmd --theme dracula --transparent -o overlay.svg",
-        "  diagramforge diagram.mmd --theme-file mytheme.json -o out.svg"
+        "  dnx DiagramForge.Tool diagram.mmd --output diagram.svg",
+        "  dnx DiagramForge.Tool diagram.mmd --theme dark --output diagram.svg",
+        "  dnx DiagramForge.Tool diagram.mmd --theme dark --palette '[\"#FF6B6B\",\"#4ECDC4\",\"#45B7D1\"]' -o out.svg",
+        "  dnx DiagramForge.Tool diagram.mmd --theme dracula --transparent -o overlay.svg",
+        "  dnx DiagramForge.Tool diagram.mmd --theme-file mytheme.json -o out.svg"
     ];
 
     Console.WriteLine(string.Join(Environment.NewLine, lines));


### PR DESCRIPTION
## Summary

Updates the README, package readme, and built-in CLI help text to prefer `.NET 10` `dnx DiagramForge.Tool ...` usage over installed-tool command examples.

## What changed

- update `README.md` CLI install/usage examples to use `dnx DiagramForge.Tool ...`
- update `doc/PackageReadme.md` CLI install/usage examples to use `dnx DiagramForge.Tool ...`
- update `src/DiagramForge.Cli/Program.cs` help output examples to match the same guidance

## Why

Since DiagramForge targets `.NET 10`, the preferred way to run the tool is via `dnx DiagramForge.Tool ...` without requiring a prior global tool install. This keeps the docs and help text aligned with the recommended workflow.

## Validation

- checked resulting diffs for all three surfaces
- verified no diagnostics/errors in the modified files