### PR TITLE
Add local package troubleshooting guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ If local testing behaves differently from the published NuGet package, check whe
 - Clear caches with `dotnet nuget locals all --clear`
 - Remove stale package folders such as `%USERPROFILE%\.nuget\packages\diagramforge\1.0.0`
 - Be careful with local sources like `artifacts/nupkg`, `--add-source`, or custom `NuGet.Config` entries
-- If needed, validate the published package explicitly with `RestoreSources=https://api.nuget.org/v3/index.json` and an isolated `RestorePackagesPath`
+- If needed, validate the published package explicitly by running `dotnet restore -p:RestoreSources=https://api.nuget.org/v3/index.json -p:RestorePackagesPath=./artifacts/isolated-packages` (or a similar isolated folder)
 
 Matching package ID and version do not guarantee matching bits. When diagnosing package issues, compare package or DLL hashes before assuming the published package is wrong.
 


### PR DESCRIPTION
## Summary
Adds contributor guidance for diagnosing cases where local package caches or package sources differ from the published NuGet package.

## Changes
- document cache clearing and stale package folder checks
- call out local sources such as `artifacts/nupkg`, `--add-source`, and custom `NuGet.Config`
- suggest validating against nuget.org with isolated restore settings
- note that matching package ID and version do not guarantee matching bits

## Validation
- documentation-only change