### PR TITLE
Add class diagram model primitives

### DIFF
--- a/src/DiagramForge/Models/Edge.cs
+++ b/src/DiagramForge/Models/Edge.cs
@@ -20,6 +20,12 @@ public class Edge
     /// <summary>Optional label displayed on the edge.</summary>
     public Label? Label { get; set; }
 
+    /// <summary>Optional label displayed near the source end of the edge.</summary>
+    public Label? SourceLabel { get; set; }
+
+    /// <summary>Optional label displayed near the target end of the edge.</summary>
+    public Label? TargetLabel { get; set; }
+
     /// <summary>Style of the edge line.</summary>
     public EdgeLineStyle LineStyle { get; set; } = EdgeLineStyle.Solid;
 

--- a/src/DiagramForge/Models/Node.cs
+++ b/src/DiagramForge/Models/Node.cs
@@ -35,6 +35,16 @@ public class Node
     /// <summary>Arbitrary metadata from the parser (e.g., Mermaid node type).</summary>
     public Dictionary<string, object> Metadata { get; } = new();
 
+    /// <summary>
+    /// Optional stereotype or annotation labels rendered above the node's primary title.
+    /// </summary>
+    public List<Label> Annotations { get; } = new();
+
+    /// <summary>
+    /// Optional ordered compartments rendered within the node body.
+    /// </summary>
+    public List<NodeCompartment> Compartments { get; } = new();
+
     /// <summary>Layout position computed by the layout engine.</summary>
     public double X { get; set; }
 

--- a/src/DiagramForge/Models/NodeCompartment.cs
+++ b/src/DiagramForge/Models/NodeCompartment.cs
@@ -1,0 +1,32 @@
+namespace DiagramForge.Models;
+
+/// <summary>
+/// An ordered section within a node, typically used for UML-style class compartments.
+/// </summary>
+public class NodeCompartment
+{
+    public NodeCompartment()
+    {
+    }
+
+    public NodeCompartment(string? kind)
+    {
+        Kind = kind;
+    }
+
+    public NodeCompartment(string? kind, IEnumerable<Label> lines)
+    {
+        Kind = kind;
+        Lines.AddRange(lines);
+    }
+
+    /// <summary>
+    /// Optional compartment role metadata such as <c>title</c>, <c>attributes</c>, or <c>methods</c>.
+    /// </summary>
+    public string? Kind { get; set; }
+
+    /// <summary>
+    /// Ordered label lines contained in the compartment.
+    /// </summary>
+    public List<Label> Lines { get; } = new();
+}

--- a/tests/DiagramForge.Tests/Models/DiagramModelTests.cs
+++ b/tests/DiagramForge.Tests/Models/DiagramModelTests.cs
@@ -80,6 +80,46 @@ public class DiagramModelTests
     }
 
     [Fact]
+    public void Node_NewClassDiagramCollections_DefaultToEmpty_WithoutChangingLegacyState()
+    {
+        var node = new Node("Customer", "Customer");
+
+        Assert.Equal("Customer", node.Label.Text);
+        Assert.Empty(node.Annotations);
+        Assert.Empty(node.Compartments);
+    }
+
+    [Fact]
+    public void Node_CompartmentsAndAnnotations_PreserveOrderAndContent()
+    {
+        var node = new Node("Order")
+        {
+            FillColor = "#ffeecc",
+        };
+
+        node.Annotations.Add(new Label("<<entity>>"));
+        node.Compartments.Add(new NodeCompartment("attributes", new[]
+        {
+            new Label("+Id: Guid"),
+            new Label("+Status: string"),
+        }));
+        node.Compartments.Add(new NodeCompartment("methods", new[]
+        {
+            new Label("+Submit()"),
+        }));
+
+        Assert.Single(node.Annotations);
+        Assert.Equal("<<entity>>", node.Annotations[0].Text);
+        Assert.Equal(2, node.Compartments.Count);
+        Assert.Equal("attributes", node.Compartments[0].Kind);
+        Assert.Equal("+Id: Guid", node.Compartments[0].Lines[0].Text);
+        Assert.Equal("+Status: string", node.Compartments[0].Lines[1].Text);
+        Assert.Equal("methods", node.Compartments[1].Kind);
+        Assert.Equal("+Submit()", node.Compartments[1].Lines[0].Text);
+        Assert.Equal("#ffeecc", node.FillColor);
+    }
+
+    [Fact]
     public void Edge_DefaultArrowHead_IsArrow()
     {
         var edge = new Edge("A", "B");
@@ -93,6 +133,34 @@ public class DiagramModelTests
         var edge = new Edge("A", "B");
 
         Assert.Equal(EdgeLineStyle.Solid, edge.LineStyle);
+    }
+
+    [Fact]
+    public void Edge_EndLabels_DefaultToNull_WithoutAffectingCenterLabel()
+    {
+        var edge = new Edge("A", "B")
+        {
+            Label = new Label("relates to"),
+        };
+
+        Assert.Equal("relates to", edge.Label?.Text);
+        Assert.Null(edge.SourceLabel);
+        Assert.Null(edge.TargetLabel);
+    }
+
+    [Fact]
+    public void Edge_CanStoreIndependentCenterSourceAndTargetLabels()
+    {
+        var edge = new Edge("Customer", "Ticket")
+        {
+            Label = new Label("owns"),
+            SourceLabel = new Label("1"),
+            TargetLabel = new Label("*"),
+        };
+
+        Assert.Equal("owns", edge.Label?.Text);
+        Assert.Equal("1", edge.SourceLabel?.Text);
+        Assert.Equal("*", edge.TargetLabel?.Text);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add additive class-diagram model primitives to `Node` and `Edge`
- introduce `NodeCompartment` for ordered class box sections
- add compatibility-focused model tests covering empty defaults and independent edge label positions

## Changes
- add `Node.Annotations` and `Node.Compartments`
- add `Edge.SourceLabel` and `Edge.TargetLabel`
- add `NodeCompartment` with optional `Kind` and ordered `Lines`
- extend model tests to verify the new members do not change existing construction behavior

## Validation
- `DiagramModelTests`: 11 passed
- full test suite: 642 passed

Closes #87