### PR TITLE
Add synthwave theme with warm sunset glow

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ DiagramForge currently supports more than a dozen diagram types across Mermaid a
 
 <h3>Built-in Themes</h3>
 
-This theme gallery is also a representative sample rather than the full catalog. DiagramForge ships with 24 built-in themes: `default`, `zinc-light`, `zinc-dark`, `dark`, `neutral`, `forest`, `presentation`, `prism`, `angled-light`, `angled-dark`, `github-light`, `github-dark`, `nord`, `nord-light`, `dracula`, `tokyo-night`, `tokyo-night-storm`, `tokyo-night-light`, `catppuccin-latte`, `catppuccin-mocha`, `solarized-light`, `solarized-dark`, `one-dark`, and `cyberpunk`. See [With a custom theme](#with-a-custom-theme), [doc/theming.md](doc/theming.md), and [doc/frontmatter.md](doc/frontmatter.md) for the full styling surface.
+This theme gallery is also a representative sample rather than the full catalog. DiagramForge ships with 25 built-in themes: `default`, `zinc-light`, `zinc-dark`, `dark`, `neutral`, `forest`, `presentation`, `prism`, `angled-light`, `angled-dark`, `github-light`, `github-dark`, `nord`, `nord-light`, `dracula`, `tokyo-night`, `tokyo-night-storm`, `tokyo-night-light`, `catppuccin-latte`, `catppuccin-mocha`, `solarized-light`, `solarized-dark`, `one-dark`, `cyberpunk`, and `synthwave`. See [With a custom theme](#with-a-custom-theme), [doc/theming.md](doc/theming.md), and [doc/frontmatter.md](doc/frontmatter.md) for the full styling surface.
 
 <table cellpadding="16" width="100%">
   <tr>
@@ -250,7 +250,13 @@ This theme gallery is also a representative sample rather than the full catalog.
       <br />
       <sub>Cyberpunk</sub>
     </td>
-    <td></td>
+    <td align="center" valign="top" width="50%">
+      <a href="https://github.com/jongalloway/DiagramForge/blob/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.expected.svg">
+        <img src="https://raw.githubusercontent.com/jongalloway/DiagramForge/main/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.expected.svg" alt="Synthwave theme" width="400" />
+      </a>
+      <br />
+      <sub>Synthwave</sub>
+    </td>
   </tr>
 </table>
 <!-- markdownlint-enable MD033 -->

--- a/doc/theming.md
+++ b/doc/theming.md
@@ -36,9 +36,9 @@ This means a diagram can carry its own preferred look, while callers can still o
 
 ## 3. Built-in Themes
 
-DiagramForge ships with 24 built-in theme presets:
+DiagramForge ships with 25 built-in theme presets:
 
-`default`, `zinc-light`, `zinc-dark`, `dark`, `neutral`, `forest`, `presentation`, `prism`, `angled-light`, `angled-dark`, `github-light`, `github-dark`, `nord`, `nord-light`, `dracula`, `tokyo-night`, `tokyo-night-storm`, `tokyo-night-light`, `catppuccin-latte`, `catppuccin-mocha`, `solarized-light`, `solarized-dark`, `one-dark`, `cyberpunk`
+`default`, `zinc-light`, `zinc-dark`, `dark`, `neutral`, `forest`, `presentation`, `prism`, `angled-light`, `angled-dark`, `github-light`, `github-dark`, `nord`, `nord-light`, `dracula`, `tokyo-night`, `tokyo-night-storm`, `tokyo-night-light`, `catppuccin-latte`, `catppuccin-mocha`, `solarized-light`, `solarized-dark`, `one-dark`, `cyberpunk`, `synthwave`
 
 Resolve a preset by name with `Theme.GetByName(string?)`.
 

--- a/src/DiagramForge/Models/Theme.cs
+++ b/src/DiagramForge/Models/Theme.cs
@@ -33,6 +33,7 @@ public class Theme
         "solarized-dark",
         "one-dark",
         "cyberpunk",
+        "synthwave",
     ];
 
     // ── Built-in named presets ────────────────────────────────────────────────
@@ -386,6 +387,9 @@ public class Theme
     /// <summary>Dark cyberpunk theme with neon glow accents and bold multi-stop border gradients.</summary>
     public static Theme Cyberpunk => CreateCyberpunkTheme();
 
+    /// <summary>Dark synthwave theme with warm sunset gradients and analog glow.</summary>
+    public static Theme Synthwave => CreateSynthwaveTheme();
+
     // ── Palette lookup ────────────────────────────────────────────────────────
 
     /// <summary>All built-in theme names supported by <see cref="GetByName(string?)"/>.</summary>
@@ -423,6 +427,7 @@ public class Theme
             "solarized-dark" => SolarizedDark,
             "one-dark" => OneDark,
             "cyberpunk" => Cyberpunk,
+            "synthwave" => Synthwave,
             _ => null,
         };
 
@@ -836,6 +841,51 @@ public class Theme
         theme.ShadowColor = "#FF2D95";
         theme.ShadowOpacity = 0.55;
         theme.ShadowBlur = 4.0;
+        theme.ShadowOffsetX = 0;
+        theme.ShadowOffsetY = 0;
+        return theme;
+    }
+
+    private static Theme CreateSynthwaveTheme()
+    {
+        var theme = CreatePreset(
+            backgroundColor: "#1A0030",
+            foregroundColor: "#F0E0FF",
+            accentColor: "#FF6EC7",
+            mutedColor: "#9080A8",
+            surfaceColor: "#2A1040",
+            borderColor: "#FF6EC7",
+            lineColor: "#FFB347",
+            nodePalette:
+            [
+                "#2A1040", "#2E1248", "#321450", "#261042",
+                "#301252", "#2C1046", "#34144E", "#281044",
+            ],
+            useGradients: true,
+            useBorderGradients: true,
+            gradientStrength: 0.16,
+            useMultiStopBorderGradient: false);
+
+        theme.NodeFillColor = "#2A1040";
+        theme.NodeStrokeColor = "#FF6EC7";
+        theme.GroupFillColor = "#2A1040E0";
+        theme.GroupStrokeColor = "#B24BF3";
+        theme.TitleTextColor = "#FFB347";
+        theme.EdgeColor = "#FFB347";
+        theme.BorderGradientStops =
+        [
+            "#FF6EC7",   // hot pink
+            "#B24BF3",   // violet
+            "#FFB347",   // sunset orange
+            "#FF3864",   // neon red-pink
+        ];
+        theme.BorderRadius = 6;
+        theme.StrokeWidth = 1.8;
+        theme.ShadowStyle = "glow";
+        theme.UseNodeShadows = true;
+        theme.ShadowColor = "#FF6EC7";
+        theme.ShadowOpacity = 0.45;
+        theme.ShadowBlur = 5.0;
         theme.ShadowOffsetX = 0;
         theme.ShadowOffsetY = 0;
         return theme;

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.expected.svg
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.expected.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720.00" height="133.00" viewBox="0 0 720.00 133.00">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FFB347"/>
+    </marker>
+    <marker id="arrowhead-open" markerWidth="12" markerHeight="9" refX="11" refY="4.50" orient="auto">
+      <polygon points="0 0, 12 4.50, 0 9" fill="#1A0030" stroke="#FFB347" stroke-width="1.50"/>
+    </marker>
+    <marker id="arrowhead-filled-diamond" markerWidth="14" markerHeight="9" refX="1" refY="4.50" orient="auto">
+      <polygon points="1 4.50, 7 1, 13 4.50, 7 8" fill="#FFB347"/>
+    </marker>
+    <marker id="arrowhead-open-diamond" markerWidth="14" markerHeight="9" refX="1" refY="4.50" orient="auto">
+      <polygon points="1 4.50, 7 1, 13 4.50, 7 8" fill="#1A0030" stroke="#FFB347" stroke-width="1.50"/>
+    </marker>
+  </defs>
+  <rect width="720.00" height="133.00" fill="#1A0030" rx="6.00" ry="6.00"/>
+  <defs>
+    <linearGradient id="group-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#48325BE0"/>
+      <stop offset="58%" stop-color="#2A1040E0"/>
+      <stop offset="100%" stop-color="#250E39E0"/>
+    </linearGradient>
+    <linearGradient id="group-0-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FF6EC7"/>
+      <stop offset="33%" stop-color="#B24BF3"/>
+      <stop offset="67%" stop-color="#FFB347"/>
+      <stop offset="100%" stop-color="#FF3864"/>
+    </linearGradient>
+  </defs>
+  <defs>
+    <filter id="group-0-glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4.00" result="glow-blur"/>
+      <feFlood flood-color="#FF6EC7" flood-opacity="0.45" result="glow-color"/>
+      <feComposite in="glow-color" in2="glow-blur" operator="in" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="24.00" y="24.00" width="324.00" height="85.00" rx="6.00" ry="6.00" fill="url(#group-0-fill-gradient)" stroke="url(#group-0-stroke-gradient)" stroke-width="1.80" filter="url(#group-0-glow)"/>
+  <rect x="34.00" y="34.00" width="88.36" height="20.66" rx="10.33" ry="10.33" fill="#3B105B" stroke="#A645E3" stroke-width="1.44"/>
+  <text x="43.00" y="48.05" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="10.66" fill="#F0E0FF" font-weight="bold">Design Loop</text>
+  <path d="M 156.00,77.00 C 180.00,77.00 192.00,77.00 216.00,77.00" fill="none" stroke="#FFB347" stroke-width="1.80" stroke-linecap="round"   marker-end="url(#arrowhead)" />
+  <path d="M 336.00,77.00 C 360.00,77.00 372.00,77.00 396.00,77.00" fill="none" stroke="#FFB347" stroke-width="1.80" stroke-linecap="round"   marker-end="url(#arrowhead)" />
+  <path d="M 516.00,77.00 C 540.00,77.00 552.00,77.00 576.00,77.00" fill="none" stroke="#FFB347" stroke-width="1.80" stroke-linecap="round"   marker-end="url(#arrowhead)" />
+  <text x="546.00" y="73.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#9080A8" font-style="italic">ship</text>
+  <path d="M 396.00,77.00 C 300.00,77.00 252.00,77.00 156.00,77.00" fill="none" stroke="#FFB347" stroke-width="1.80" stroke-linecap="round"   marker-end="url(#arrowhead)" />
+  <text x="276.00" y="73.00" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="11.05" fill="#9080A8" font-style="italic">revise</text>
+  <g transform="translate(36.00,57.00)">
+    <defs>
+      <linearGradient id="node-0-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#48325B"/>
+        <stop offset="58%" stop-color="#2A1040"/>
+        <stop offset="100%" stop-color="#250E39"/>
+      </linearGradient>
+      <linearGradient id="node-0-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#FF6EC7"/>
+        <stop offset="33%" stop-color="#B24BF3"/>
+        <stop offset="67%" stop-color="#FFB347"/>
+        <stop offset="100%" stop-color="#FF3864"/>
+      </linearGradient>
+    </defs>
+    <defs>
+      <filter id="node-0-glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="4.00" result="glow-blur"/>
+        <feFlood flood-color="#FF6EC7" flood-opacity="0.45" result="glow-color"/>
+        <feComposite in="glow-color" in2="glow-blur" operator="in" result="glow"/>
+        <feMerge>
+          <feMergeNode in="glow"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+    </defs>
+    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-0-fill-gradient)" stroke="url(#node-0-stroke-gradient)" stroke-width="1.80" filter="url(#node-0-glow)"/>
+    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#F0E0FF">Plan</text>
+  </g>
+  <g transform="translate(216.00,57.00)">
+    <defs>
+      <linearGradient id="node-1-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#4C3462"/>
+        <stop offset="58%" stop-color="#2E1248"/>
+        <stop offset="100%" stop-color="#291041"/>
+      </linearGradient>
+      <linearGradient id="node-1-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#FF6EC7"/>
+        <stop offset="33%" stop-color="#B24BF3"/>
+        <stop offset="67%" stop-color="#FFB347"/>
+        <stop offset="100%" stop-color="#FF3864"/>
+      </linearGradient>
+    </defs>
+    <defs>
+      <filter id="node-1-glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="4.00" result="glow-blur"/>
+        <feFlood flood-color="#FF6EC7" flood-opacity="0.45" result="glow-color"/>
+        <feComposite in="glow-color" in2="glow-blur" operator="in" result="glow"/>
+        <feMerge>
+          <feMergeNode in="glow"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+    </defs>
+    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-1-fill-gradient)" stroke="url(#node-1-stroke-gradient)" stroke-width="1.80" filter="url(#node-1-glow)"/>
+    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#F0E0FF">Draft</text>
+  </g>
+  <g transform="translate(396.00,57.00)">
+    <defs>
+      <linearGradient id="node-2-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#4F3569"/>
+        <stop offset="58%" stop-color="#321450"/>
+        <stop offset="100%" stop-color="#2D1248"/>
+      </linearGradient>
+      <linearGradient id="node-2-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#FF6EC7"/>
+        <stop offset="33%" stop-color="#B24BF3"/>
+        <stop offset="67%" stop-color="#FFB347"/>
+        <stop offset="100%" stop-color="#FF3864"/>
+      </linearGradient>
+    </defs>
+    <defs>
+      <filter id="node-2-glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="4.00" result="glow-blur"/>
+        <feFlood flood-color="#FF6EC7" flood-opacity="0.45" result="glow-color"/>
+        <feComposite in="glow-color" in2="glow-blur" operator="in" result="glow"/>
+        <feMerge>
+          <feMergeNode in="glow"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+    </defs>
+    <polygon points="60.00,0 120.00,20.00 60.00,40.00 0,20.00" fill="url(#node-2-fill-gradient)" stroke="url(#node-2-stroke-gradient)" stroke-width="1.80" filter="url(#node-2-glow)"/>
+    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#F0E0FF">Review</text>
+  </g>
+  <g transform="translate(576.00,57.00)">
+    <defs>
+      <linearGradient id="node-3-fill-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stop-color="#45325D"/>
+        <stop offset="58%" stop-color="#261042"/>
+        <stop offset="100%" stop-color="#220E3B"/>
+      </linearGradient>
+      <linearGradient id="node-3-stroke-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+        <stop offset="0%" stop-color="#FF6EC7"/>
+        <stop offset="33%" stop-color="#B24BF3"/>
+        <stop offset="67%" stop-color="#FFB347"/>
+        <stop offset="100%" stop-color="#FF3864"/>
+      </linearGradient>
+    </defs>
+    <defs>
+      <filter id="node-3-glow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="4.00" result="glow-blur"/>
+        <feFlood flood-color="#FF6EC7" flood-opacity="0.45" result="glow-color"/>
+        <feComposite in="glow-color" in2="glow-blur" operator="in" result="glow"/>
+        <feMerge>
+          <feMergeNode in="glow"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
+    </defs>
+    <rect width="120.00" height="40.00" rx="0" ry="0" fill="url(#node-3-fill-gradient)" stroke="url(#node-3-stroke-gradient)" stroke-width="1.80" filter="url(#node-3-glow)"/>
+    <text x="60.00" y="24.55" text-anchor="middle" font-family="&quot;Segoe UI&quot;, Inter, Arial, sans-serif" font-size="13.00" fill="#F0E0FF">Publish</text>
+  </g>
+</svg>

--- a/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.input
+++ b/tests/DiagramForge.E2ETests/Fixtures/mermaid-theme-synthwave.input
@@ -1,0 +1,10 @@
+---
+theme: synthwave
+---
+flowchart LR
+  subgraph team [Design Loop]
+    A[Plan] --> B[Draft]
+  end
+  B --> C{Review}
+  C -->|ship| D[Publish]
+  C -->|revise| A

--- a/tests/DiagramForge.Tests/Models/ThemeTests.cs
+++ b/tests/DiagramForge.Tests/Models/ThemeTests.cs
@@ -221,12 +221,29 @@ public class ThemeTests
         Assert.Contains("nord-light", Theme.BuiltInThemeNames);
         Assert.Contains("github-dark", Theme.BuiltInThemeNames);
         Assert.Contains("cyberpunk", Theme.BuiltInThemeNames);
+        Assert.Contains("synthwave", Theme.BuiltInThemeNames);
     }
 
     [Fact]
     public void Cyberpunk_UsesNeonGlowOnDarkBackground()
     {
         var theme = Theme.Cyberpunk;
+
+        Assert.True(ColorUtils.GetLuminance(theme.BackgroundColor) < 40);
+        Assert.True(theme.UseGradients);
+        Assert.True(theme.UseBorderGradients);
+        Assert.NotNull(theme.BorderGradientStops);
+        Assert.True(theme.BorderGradientStops!.Count >= 4);
+        Assert.Equal("glow", theme.ShadowStyle);
+        Assert.True(theme.UseNodeShadows);
+        Assert.Equal(0, theme.ShadowOffsetX);
+        Assert.Equal(0, theme.ShadowOffsetY);
+    }
+
+    [Fact]
+    public void Synthwave_UsesSunsetGlowOnDarkBackground()
+    {
+        var theme = Theme.Synthwave;
 
         Assert.True(ColorUtils.GetLuminance(theme.BackgroundColor) < 40);
         Assert.True(theme.UseGradients);
@@ -280,6 +297,7 @@ public class ThemeTests
     [InlineData("dracula")]
     [InlineData("tokyo-night")]
     [InlineData("cyberpunk")]
+    [InlineData("synthwave")]
     public void BuiltInTheme_SelectedThemes_UseExpressiveMultiStopBorderGradients(string name)
     {
         var theme = Theme.GetByName(name)!;
@@ -347,6 +365,7 @@ public class ThemeTests
     [InlineData("angled-light")]
     [InlineData("angled-dark")]
     [InlineData("cyberpunk")]
+    [InlineData("synthwave")]
     public void BuiltInTheme_TextColor_HasSufficientContrastAgainstNodeFill(string themeName)
     {
         var theme = Theme.GetByName(themeName)!;


### PR DESCRIPTION
## Summary

Adds a new **synthwave** built-in theme (25th theme), leveraging the glow shadow infrastructure from the cyberpunk theme but with a distinctly warmer, analog-inspired palette.

## Visual identity

| Property | Value |
|---|---|
| Background | `#1A0030` (deep purple) |
| Accents | hot pink `#FF6EC7`, sunset orange `#FFB347`, violet `#B24BF3`, neon red-pink `#FF3864` |
| Glow | pink `#FF6EC7` at 0.45 opacity, 5px blur (softer/wider than cyberpunk) |
| Gradient strength | 0.16 |
| Border gradients | 4-stop sunset: pink → violet → orange → red-pink |

Key distinction from cyberpunk: warmer palette (no cyan/green), softer glow, purple-shifted background — reads as *retro analog synth* vs cyberpunk's *neon-on-wet-streets*.

## Changes

- **Theme.cs** — `Synthwave` property, `CreateSynthwaveTheme()` factory, array/switch entries
- **ThemeTests.cs** — `Synthwave_UsesSunsetGlowOnDarkBackground` test + added to contrast and gradient theories
- **E2E fixture** — `mermaid-theme-synthwave.input` + generated `.expected.svg` baseline
- **README.md** — gallery row (fills the empty cell next to Cyberpunk), theme count → 25
- **doc/theming.md** — theme list updated

## Test results

All 943 tests pass (854 unit + 89 E2E).